### PR TITLE
Safe Harness for FV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ fabric.properties
 
 # Certora
 .certora_internal
+
+# VS Code
+.vscode

--- a/certora/conf/SocialRecoveryModule.conf
+++ b/certora/conf/SocialRecoveryModule.conf
@@ -5,6 +5,7 @@
     ],
     "msg": "SocialRecoveryModule: General Ruleset",
     "rule_sanity": "basic",
+    "solc": "solc-0.8.23",
     "verify": "SocialRecoveryModule:certora/specs/SocialRecoveryModule.spec",
     "packages": [
         "@safe-global=node_modules/@safe-global",

--- a/certora/conf/SocialRecoveryModule.conf
+++ b/certora/conf/SocialRecoveryModule.conf
@@ -1,9 +1,14 @@
 {
     "files": [
         "contracts/modules/social_recovery/SocialRecoveryModule.sol",
+        "certora/harnesses/SafeHarness.sol"
     ],
     "msg": "SocialRecoveryModule: General Ruleset",
     "rule_sanity": "basic",
     "solc": "solc-0.8.23",
     "verify": "SocialRecoveryModule:certora/specs/SocialRecoveryModule.spec",
+    "packages": [
+        "@safe-global=node_modules/@safe-global",
+        "@openzeppelin=node_modules/@openzeppelin"
+    ]
 }

--- a/certora/conf/SocialRecoveryModule.conf
+++ b/certora/conf/SocialRecoveryModule.conf
@@ -5,7 +5,6 @@
     ],
     "msg": "SocialRecoveryModule: General Ruleset",
     "rule_sanity": "basic",
-    "solc": "solc-0.8.23",
     "verify": "SocialRecoveryModule:certora/specs/SocialRecoveryModule.spec",
     "packages": [
         "@safe-global=node_modules/@safe-global",

--- a/certora/harnesses/SafeHarness.sol
+++ b/certora/harnesses/SafeHarness.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.12 <0.9.0;
+import {Safe} from "@safe-global/safe-contracts/contracts/Safe.sol";
+
+contract SafeHarness is Safe {
+}

--- a/certora/specs/SocialRecoveryModule.spec
+++ b/certora/specs/SocialRecoveryModule.spec
@@ -8,13 +8,13 @@ methods {
 
 // A setup function that requires Safe contract to enabled the Social Recovery
 // Module.
-function setupRequireSafeTokenInvariants() {
+function setupRequireRecoveryModule() {
     require(safeContract.isModuleEnabled(currentContract));
 }
 
 // This is a dummy rule to verify the Safe Contract Setup with the Social Recovery
 // Module is working as intended.
-rule SocialRecoveryModuleEnabled {
+rule recoveryModuleCanBeDisabled {
     env e;
     address prevModule;
 

--- a/certora/specs/SocialRecoveryModule.spec
+++ b/certora/specs/SocialRecoveryModule.spec
@@ -1,3 +1,27 @@
-rule demo() {
-    assert true;
+using SafeHarness as safeContract;
+
+methods {
+    // Safe Functions
+    function safeContract.isModuleEnabled(address) external returns (bool) envfree;
+    function safeContract.disableModule(address, address) external;
+}
+
+// A setup function that requires Safe contract to enabled the Social Recovery
+// Module.
+function setupRequireSafeTokenInvariants() {
+    require(safeContract.isModuleEnabled(currentContract));
+}
+
+// This is a dummy rule to verify the Safe Contract Setup with the Social Recovery
+// Module is working as intended.
+rule SocialRecoveryModuleEnabled {
+    env e;
+    address prevModule;
+
+    setupRequireSafeTokenInvariants();
+
+    safeContract.disableModule@withrevert(e, prevModule, currentContract);
+    bool isReverted = lastReverted;
+
+    assert isReverted || (!isReverted && !safeContract.isModuleEnabled(currentContract));
 }

--- a/certora/specs/SocialRecoveryModule.spec
+++ b/certora/specs/SocialRecoveryModule.spec
@@ -3,12 +3,11 @@ using SafeHarness as safeContract;
 methods {
     // Safe Functions
     function safeContract.isModuleEnabled(address) external returns (bool) envfree;
-    function safeContract.disableModule(address, address) external;
 }
 
 // A setup function that requires Safe contract to enabled the Social Recovery
 // Module.
-function setupRequireRecoveryModule() {
+function requireSocialRecoveryModuleEnabled() {
     require(safeContract.isModuleEnabled(currentContract));
 }
 
@@ -18,10 +17,10 @@ rule recoveryModuleCanBeDisabled {
     env e;
     address prevModule;
 
-    setupRequireRecoveryModule();
+    requireSocialRecoveryModuleEnabled();
 
     safeContract.disableModule@withrevert(e, prevModule, currentContract);
     bool isReverted = lastReverted;
 
-    assert isReverted || (!isReverted && !safeContract.isModuleEnabled(currentContract));
+    assert !isReverted => !isReverted && !safeContract.isModuleEnabled(currentContract);
 }

--- a/certora/specs/SocialRecoveryModule.spec
+++ b/certora/specs/SocialRecoveryModule.spec
@@ -18,7 +18,7 @@ rule recoveryModuleCanBeDisabled {
     env e;
     address prevModule;
 
-    setupRequireSafeTokenInvariants();
+    setupRequireRecoveryModule();
 
     safeContract.disableModule@withrevert(e, prevModule, currentContract);
     bool isReverted = lastReverted;


### PR DESCRIPTION
This PR sets up the Safe Harness along with a dummy rule to test the functionality of the same.

Instead of using `link` as we had for the `safe-locking` setup, we are using a function called `requireSocialRecoveryModuleEnabled(...)` which requires that the `SocialRecoveryModule` is enabled for the Safe.

Fixes #2 