### PR TITLE
Inherit guardian storage

### DIFF
--- a/certora/conf/GuardianStorage.conf
+++ b/certora/conf/GuardianStorage.conf
@@ -1,7 +1,6 @@
 {
     "files": [
-        "certora/harnesses/GuardianStorageHarness.sol",
-        "contracts/modules/social_recovery/SocialRecoveryModule.sol",
+        "certora/harnesses/SocialRecoveryModuleHarness.sol",
         "certora/harnesses/SafeHarness.sol"
     ],
     "msg": "GuardianManager: General Ruleset",
@@ -17,9 +16,9 @@
     "prover_args": [
         "-smt_groundQuantifiers true -depth 0"
     ],
-    "verify": "GuardianStorageHarness:certora/specs/GuardianStorage.spec",
+    "verify": "SocialRecoveryModuleHarness:certora/specs/GuardianStorage.spec",
     "parametric_contracts" : [
-        "GuardianStorageHarness"
+        "SocialRecoveryModuleHarness"
     ],
     "packages": [
         "@safe-global=node_modules/@safe-global",

--- a/certora/conf/SocialRecoveryModule.conf
+++ b/certora/conf/SocialRecoveryModule.conf
@@ -8,6 +8,9 @@
     "rule_sanity": "basic",
     "solc": "solc-0.8.20",
     "verify": "SocialRecoveryModuleHarness:certora/specs/SocialRecoveryModule.spec",
+    "parametric_contracts" : [
+        "SocialRecoveryModuleHarness"
+    ],
     "packages": [
         "@safe-global=node_modules/@safe-global",
         "@openzeppelin=node_modules/@openzeppelin"

--- a/certora/conf/SocialRecoveryModule.conf
+++ b/certora/conf/SocialRecoveryModule.conf
@@ -3,10 +3,7 @@
         "certora/harnesses/SocialRecoveryModuleHarness.sol",
         "certora/harnesses/GuardianStorageHarness.sol",
         "certora/harnesses/SafeHarness.sol"
-    ],
-    "link": [
-        "SocialRecoveryModuleHarness:guardianStorage=GuardianStorageHarness"
-    ],    
+    ],   
     "msg": "SocialRecoveryModule: General Ruleset",
     "rule_sanity": "basic",
     "solc": "solc-0.8.20",

--- a/certora/conf/SocialRecoveryModule.conf
+++ b/certora/conf/SocialRecoveryModule.conf
@@ -1,7 +1,6 @@
 {
     "files": [
         "certora/harnesses/SocialRecoveryModuleHarness.sol",
-        "certora/harnesses/GuardianStorageHarness.sol",
         "certora/harnesses/SafeHarness.sol"
     ],   
     "msg": "SocialRecoveryModule: General Ruleset",

--- a/certora/harnesses/GuardianStorageHarness.sol
+++ b/certora/harnesses/GuardianStorageHarness.sol
@@ -3,30 +3,4 @@ pragma solidity >=0.8.12 <0.9.0;
 
 import {GuardianStorage} from "../../contracts/modules/social_recovery/storage/GuardianStorage.sol";
 
-contract GuardianStorageHarness is GuardianStorage {
-    /**
-     * @notice Counts the guardians by iterating through the linked list starting at the sentinel address,
-     * instead of relying on the count storage variable.
-     * @dev This would not count "shadow" guardians that are not part of the linked list, which would
-     * never happen assuming integrity of the linked list.
-     * @param _wallet The target wallet.
-     * @return count of guardians.
-     */
-    function countGuardians(address _wallet) public view returns (uint256 count) {
-        GuardianStorageEntry storage entry = entries[_wallet];
-        address currentGuardian = entry.guardians[SENTINEL_GUARDIANS];
-
-        // The sentinel guardian pointing to address 0 is the initial state for the
-        // guardian storage entry for an account and is equivalent to an empty list
-        // where the sentinel points to itself. We handle this special case here.
-        if (currentGuardian == address(0)) {
-            return 0;
-        }
-
-        while (currentGuardian != SENTINEL_GUARDIANS) {
-            currentGuardian = entry.guardians[currentGuardian];
-            require(currentGuardian != address(0), "Guardian is address(0)");
-            count++;
-        }
-    }
-}
+contract GuardianStorageHarness is GuardianStorage {}

--- a/certora/harnesses/GuardianStorageHarness.sol
+++ b/certora/harnesses/GuardianStorageHarness.sol
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.12 <0.9.0;
-
-import {GuardianStorage} from "../../contracts/modules/social_recovery/storage/GuardianStorage.sol";
-
-contract GuardianStorageHarness is GuardianStorage {}

--- a/certora/harnesses/SocialRecoveryModuleHarness.sol
+++ b/certora/harnesses/SocialRecoveryModuleHarness.sol
@@ -4,5 +4,5 @@ import {SocialRecoveryModule} from "../../contracts/modules/social_recovery/Soci
 import {IGuardianStorage} from "../../contracts/modules/social_recovery/storage/IGuardianStorage.sol";
 
 contract SocialRecoveryModuleHarness is SocialRecoveryModule {
-    constructor(IGuardianStorage _guardianStorage, uint256 _recoveryPeriod) SocialRecoveryModule(_guardianStorage, _recoveryPeriod) {}
+    constructor(uint256 _recoveryPeriod) SocialRecoveryModule(_recoveryPeriod) {}
 }

--- a/certora/harnesses/SocialRecoveryModuleHarness.sol
+++ b/certora/harnesses/SocialRecoveryModuleHarness.sol
@@ -5,4 +5,30 @@ import {IGuardianStorage} from "../../contracts/modules/social_recovery/storage/
 
 contract SocialRecoveryModuleHarness is SocialRecoveryModule {
     constructor(uint256 _recoveryPeriod) SocialRecoveryModule(_recoveryPeriod) {}
+
+    /**
+     * @notice Counts the guardians by iterating through the linked list starting at the sentinel address,
+     * instead of relying on the count storage variable.
+     * @dev This would not count "shadow" guardians that are not part of the linked list, which would
+     * never happen assuming integrity of the linked list.
+     * @param _wallet The target wallet.
+     * @return count of guardians.
+     */
+    function countGuardians(address _wallet) public view returns (uint256 count) {
+        GuardianStorageEntry storage entry = entries[_wallet];
+        address currentGuardian = entry.guardians[SENTINEL_GUARDIANS];
+
+        // The sentinel guardian pointing to address 0 is the initial state for the
+        // guardian storage entry for an account and is equivalent to an empty list
+        // where the sentinel points to itself. We handle this special case here.
+        if (currentGuardian == address(0)) {
+            return 0;
+        }
+
+        while (currentGuardian != SENTINEL_GUARDIANS) {
+            currentGuardian = entry.guardians[currentGuardian];
+            require(currentGuardian != address(0), "Guardian is address(0)");
+            count++;
+        }
+    }
 }

--- a/certora/specs/GuardianStorage.spec
+++ b/certora/specs/GuardianStorage.spec
@@ -366,6 +366,7 @@ rule addGuardianChangesEntries {
     address toAdd;
     uint256 threshold;
     env e;
+    require e.msg.sender == safeContract;
     require safeContract.isModuleEnabled(e.msg.sender);
 
     requireInvariant reachNull();
@@ -375,7 +376,7 @@ rule addGuardianChangesEntries {
     requireInvariant countZeroIffListEmpty();
     require other != toAdd;
     bool isGuardianOtherBefore = isGuardian(safeContract, other);
-    addGuardianWithThreshold(e, safeContract, toAdd, threshold);
+    addGuardianWithThreshold(e, toAdd, threshold);
 
     assert isGuardian(safeContract, toAdd), "addGuardian should add the given guardian";
     assert isGuardian(safeContract, other) == isGuardianOtherBefore, "addGuardian should not remove or add other guardians";
@@ -388,6 +389,7 @@ rule removeGuardianChangesGuardians {
     address prevGuardian;
     uint256 threshold;
     env e;
+    require e.msg.sender == safeContract;
     require safeContract.isModuleEnabled(e.msg.sender);
 
     requireInvariant reachNull();
@@ -396,7 +398,7 @@ rule removeGuardianChangesGuardians {
     requireInvariant reachableInList();
     require other != toRemove;
     bool isGuardianOtherBefore = isGuardian(safeContract, other);
-    revokeGuardianWithThreshold(e, safeContract, prevGuardian, toRemove, threshold);
+    revokeGuardianWithThreshold(e, prevGuardian, toRemove, threshold);
 
     assert !isGuardian(safeContract, toRemove), "revokeGuardian should remove the given guardian";
     assert isGuardian(safeContract, other) == isGuardianOtherBefore, "revokeGuardian should not remove or add other guardians";

--- a/certora/specs/GuardianStorage.spec
+++ b/certora/specs/GuardianStorage.spec
@@ -370,6 +370,7 @@ rule addGuardianChangesEntries {
     address toAdd;
     uint256 threshold;
     env e;
+    require e.msg.sender == safeContract;
     require safeContract.isModuleEnabled(e.msg.sender);
 
     requireInvariant reachNull();
@@ -379,7 +380,7 @@ rule addGuardianChangesEntries {
     requireInvariant countZeroIffListEmpty();
     require other != toAdd;
     bool isGuardianOtherBefore = isGuardian(safeContract, other);
-    addGuardianWithThreshold(e, safeContract, toAdd, threshold);
+    addGuardianWithThreshold(e, toAdd, threshold);
 
     assert isGuardian(safeContract, toAdd), "addGuardian should add the given guardian";
     assert isGuardian(safeContract, other) == isGuardianOtherBefore, "addGuardian should not remove or add other guardians";
@@ -392,6 +393,7 @@ rule removeGuardianChangesGuardians {
     address prevGuardian;
     uint256 threshold;
     env e;
+    require e.msg.sender == safeContract;
     require safeContract.isModuleEnabled(e.msg.sender);
 
     requireInvariant reachNull();
@@ -400,7 +402,7 @@ rule removeGuardianChangesGuardians {
     requireInvariant reachableInList();
     require other != toRemove;
     bool isGuardianOtherBefore = isGuardian(safeContract, other);
-    revokeGuardianWithThreshold(e, safeContract, prevGuardian, toRemove, threshold);
+    revokeGuardianWithThreshold(e, prevGuardian, toRemove, threshold);
 
     assert !isGuardian(safeContract, toRemove), "revokeGuardian should remove the given guardian";
     assert isGuardian(safeContract, other) == isGuardianOtherBefore, "revokeGuardian should not remove or add other guardians";

--- a/certora/specs/GuardianStorage.spec
+++ b/certora/specs/GuardianStorage.spec
@@ -54,7 +54,7 @@ persistent ghost address NULL {
     axiom to_mathint(NULL) == 0;
 }
 
-// Verifies that if threshold Zero there sghould be no guardian.
+// Verifies that if the threshold is Zero, then there should be no guardian.
 invariant guardianCountZeroIffThresholdZero(address wallet)
     threshold(wallet) == 0 <=> ghostGuardianCount[wallet] == 0
     {
@@ -78,7 +78,7 @@ invariant thresholdSet(address wallet)
         }
     }
 
-// every element with 0 in the guardians field can only reach the null pointer and itself
+// Every element with 0 in the guardians field can only reach the null pointer and itself.
 invariant nextNull()
     (forall address wallet. ghostGuardians[wallet][NULL] == 0) &&
     (forall address wallet. forall address X. forall address Y. ghostGuardians[wallet][X] == 0 && ghostReach(wallet, X, Y) => X == Y || Y == 0)
@@ -91,7 +91,7 @@ invariant nextNull()
         }
     }
 
-// every element reaches the 0 pointer (because we replace in reach the end sentinel with null)
+// Every element reaches the 0 pointer (because we replace in reach the end sentinel with null).
 invariant reachNull()
     (forall address wallet. forall address X. ghostReach(wallet, X, NULL))
     {
@@ -102,7 +102,7 @@ invariant reachNull()
         }
     }
 
-// every element that is reachable from another element is either the null pointer or part of the list.
+// Every element reachable from another element is either the null pointer or part of the list.
 invariant reachableInList()
     (forall address wallet. forall address X. forall address Y. ghostReach(wallet, X, Y) => X == Y || Y == 0 || ghostGuardians[wallet][Y] != 0)
     {
@@ -116,7 +116,7 @@ invariant reachableInList()
         }
     }
 
-// reach encodes a linear order. This axiom corresponds to Table 2 in [1].
+// Reach encodes a linear order. This axiom corresponds to Table 2 in [1].
 invariant reachInvariant()
     forall address wallet. forall address X. forall address Y. forall address Z. (
         ghostReach(wallet, X, X)
@@ -146,7 +146,7 @@ invariant inListReachable()
         }
     }
 
-// Checks that every element that is reachable from SENTINEL is part of the guardians list
+// Checks that every element reachable from SENTINEL is part of the guardians list.
 invariant reachHeadNext()
     forall address wallet. forall address X. (ghostReach(wallet, SENTINEL, X) && X != SENTINEL && X != NULL) =>
            (ghostGuardians[wallet][SENTINEL] != SENTINEL && ghostReach(wallet, ghostGuardians[wallet][SENTINEL], X))
@@ -162,7 +162,7 @@ invariant reachHeadNext()
         }
     }
 
-// every element reaches its direct successor (except for the tail-SENTINEL).
+// Every element reaches its direct successor (except for the tail-SENTINEL).
 invariant reachNext()
     forall address wallet. forall address X. reachSucc(wallet, X, ghostGuardians[wallet][X])
     {
@@ -306,6 +306,8 @@ invariant emptyListNotReachable()
         }
     }
 
+// This rule asserts that invariants related to reachability and count in the guardians list hold true after updating a guardian for a wallet.
+// It also checks updating a guardian for a wallet does not impact another wallet.
 rule storeHookPreservesInvariants(address wallet, address key, address value) {
     // These are checked in the hook.
     require key != NULL;

--- a/certora/specs/SocialRecoveryModule.spec
+++ b/certora/specs/SocialRecoveryModule.spec
@@ -125,7 +125,7 @@ rule addGuardianWorksAsExpected(env e, address guardian, uint256 threshold, addr
     uint256 currentGuardiansCount = guardianStorageContract.entries[safeContract].count;
     bool otherAccountIsGuardian = currentContract.isGuardian(safeContract, otherAccount);
 
-    currentContract.addGuardianWithThreshold(e, safeContract, guardian, threshold);
+    currentContract.addGuardianWithThreshold(e, guardian, threshold);
 
     assert safeContract.isModuleEnabled(currentContract);
     assert e.msg.sender == safeContract;
@@ -162,7 +162,7 @@ rule guardianCanAlwaysBeAdded(env e, address guardian, uint256 threshold) {
 
     // Safe contract should be the sender of the transaction.
     require e.msg.sender == safeContract;
-    currentContract.addGuardianWithThreshold@withrevert(e, safeContract, guardian, threshold);
+    currentContract.addGuardianWithThreshold@withrevert(e, guardian, threshold);
     bool isReverted = lastReverted;
 
     assert !isReverted &&
@@ -174,7 +174,7 @@ rule guardianCanAlwaysBeAdded(env e, address guardian, uint256 threshold) {
 rule addGuardianRevertPossibilities(env e, address guardian, uint256 threshold) {
     bool isGuardian = currentContract.isGuardian(safeContract, guardian);
 
-    currentContract.addGuardianWithThreshold@withrevert(e, safeContract, guardian, threshold);
+    currentContract.addGuardianWithThreshold@withrevert(e, guardian, threshold);
     bool isReverted = lastReverted;
 
     assert isReverted =>
@@ -205,7 +205,7 @@ rule revokeGuardiansWorksAsExpected(env e, address guardian, address prevGuardia
 
     uint256 currentGuardiansCount = guardianStorageContract.entries[safeContract].count;
 
-    currentContract.revokeGuardianWithThreshold(e, safeContract, prevGuardian, guardian, threshold);
+    currentContract.revokeGuardianWithThreshold(e, prevGuardian, guardian, threshold);
 
     assert safeContract.isModuleEnabled(currentContract);
     assert e.msg.sender == safeContract;
@@ -237,7 +237,7 @@ rule guardianCanAlwaysBeRevoked(env e, address guardian, address prevGuardian, u
 
     // Safe Contract should be the sender of the transaction.
     require e.msg.sender == safeContract;
-    currentContract.revokeGuardianWithThreshold@withrevert(e, safeContract, prevGuardian, guardian, threshold);
+    currentContract.revokeGuardianWithThreshold@withrevert(e, prevGuardian, guardian, threshold);
     bool isReverted = lastReverted;
 
     assert !isReverted &&
@@ -252,7 +252,7 @@ rule revokeGuardianRevertPossibilities(env e, address prevGuardian, address guar
 
     bool isGuardian = currentContract.isGuardian(safeContract, guardian);
 
-    currentContract.revokeGuardianWithThreshold@withrevert(e, safeContract, prevGuardian, guardian, threshold);
+    currentContract.revokeGuardianWithThreshold@withrevert(e, prevGuardian, guardian, threshold);
     bool isReverted = lastReverted;
 
     assert isReverted =>

--- a/certora/specs/SocialRecoveryModule.spec
+++ b/certora/specs/SocialRecoveryModule.spec
@@ -97,7 +97,7 @@ rule addGuardianWorksAsExpected(env e, address guardian, uint256 threshold, addr
     uint256 currentGuardiansCount = guardianStorageContract.entries[safeContract].count;
     bool otherAccountIsGuardian = currentContract.isGuardian(safeContract, otherAccount);
 
-    currentContract.addGuardianWithThreshold(e, safeContract, guardian, threshold);
+    currentContract.addGuardianWithThreshold(e, guardian, threshold);
 
     assert safeContract.isModuleEnabled(currentContract);
     assert e.msg.sender == safeContract;
@@ -134,7 +134,7 @@ rule guardianCanAlwaysBeAdded(env e, address guardian, uint256 threshold) {
 
     // Safe contract should be the sender of the transaction.
     require e.msg.sender == safeContract;
-    currentContract.addGuardianWithThreshold@withrevert(e, safeContract, guardian, threshold);
+    currentContract.addGuardianWithThreshold@withrevert(e, guardian, threshold);
     bool isReverted = lastReverted;
 
     assert !isReverted &&
@@ -146,7 +146,7 @@ rule guardianCanAlwaysBeAdded(env e, address guardian, uint256 threshold) {
 rule addGuardianRevertPossibilities(env e, address guardian, uint256 threshold) {
     bool isGuardian = currentContract.isGuardian(safeContract, guardian);
 
-    currentContract.addGuardianWithThreshold@withrevert(e, safeContract, guardian, threshold);
+    currentContract.addGuardianWithThreshold@withrevert(e, guardian, threshold);
     bool isReverted = lastReverted;
 
     assert isReverted =>
@@ -177,7 +177,7 @@ rule revokeGuardiansWorksAsExpected(env e, address guardian, address prevGuardia
 
     uint256 currentGuardiansCount = guardianStorageContract.entries[safeContract].count;
 
-    currentContract.revokeGuardianWithThreshold(e, safeContract, prevGuardian, guardian, threshold);
+    currentContract.revokeGuardianWithThreshold(e, prevGuardian, guardian, threshold);
 
     assert safeContract.isModuleEnabled(currentContract);
     assert e.msg.sender == safeContract;
@@ -209,7 +209,7 @@ rule guardianCanAlwaysBeRevoked(env e, address guardian, address prevGuardian, u
 
     // Safe Contract should be the sender of the transaction.
     require e.msg.sender == safeContract;
-    currentContract.revokeGuardianWithThreshold@withrevert(e, safeContract, prevGuardian, guardian, threshold);
+    currentContract.revokeGuardianWithThreshold@withrevert(e, prevGuardian, guardian, threshold);
     bool isReverted = lastReverted;
 
     assert !isReverted &&
@@ -224,7 +224,7 @@ rule revokeGuardianRevertPossibilities(env e, address prevGuardian, address guar
 
     bool isGuardian = currentContract.isGuardian(safeContract, guardian);
 
-    currentContract.revokeGuardianWithThreshold@withrevert(e, safeContract, prevGuardian, guardian, threshold);
+    currentContract.revokeGuardianWithThreshold@withrevert(e, prevGuardian, guardian, threshold);
     bool isReverted = lastReverted;
 
     assert isReverted =>

--- a/certora/specs/SocialRecoveryModule.spec
+++ b/certora/specs/SocialRecoveryModule.spec
@@ -366,7 +366,7 @@ rule cancelRecovery(env e) {
     require currentContract.recoveryRequests[safeContract].executeAfter > 0;
     require currentContract.walletsNonces[safeContract] > 0;
 
-    currentContract.cancelRecovery@withrevert(e, safeContract);
+    currentContract.cancelRecovery@withrevert(e);
     assert !lastReverted;
 }
 
@@ -384,7 +384,7 @@ rule cancelRecoveryDoesNotAffectOtherWallet(env e, address otherWallet) {
     require currentContract.recoveryRequests[safeContract].executeAfter > 0;
     require currentContract.walletsNonces[safeContract] > 0;
 
-    currentContract.cancelRecovery(e, safeContract);
+    currentContract.cancelRecovery(e);
 
     SocialRecoveryModule.RecoveryRequest otherRequestAfter = currentContract.getRecoveryRequest(e, otherWallet);
 

--- a/contracts/modules/social_recovery/SocialRecoveryModule.sol
+++ b/contracts/modules/social_recovery/SocialRecoveryModule.sol
@@ -50,14 +50,6 @@ contract SocialRecoveryModule is GuardianStorage {
     event RecoveryCanceled(address indexed wallet, uint256 nonce);
 
     /**
-     * @notice Throws if the sender is not the module itself or the owner of the target wallet.
-     */
-    modifier authorized(address _wallet) {
-        require(msg.sender == _wallet, "SM: unauthorized");
-        _;
-    }
-
-    /**
      * @notice Throws if there is no ongoing recovery request.
      */
     modifier whenRecovery(address _wallet) {
@@ -296,11 +288,10 @@ contract SocialRecoveryModule is GuardianStorage {
 
     /**
      * @notice Lets the owner cancel an ongoing recovery request.
-     * @param _wallet The target wallet.
      */
-    function cancelRecovery(address _wallet) external authorized(_wallet) whenRecovery(_wallet) {
-        delete recoveryRequests[_wallet];
-        emit RecoveryCanceled(_wallet, walletsNonces[_wallet] - 1);
+    function cancelRecovery() external whenRecovery(msg.sender) {
+        delete recoveryRequests[msg.sender];
+        emit RecoveryCanceled(msg.sender, walletsNonces[msg.sender] - 1);
     }
 
     /**

--- a/contracts/modules/social_recovery/SocialRecoveryModule.sol
+++ b/contracts/modules/social_recovery/SocialRecoveryModule.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.12 <0.9.0;
 
-import {IGuardianStorage} from "./storage/IGuardianStorage.sol";
+import {GuardianStorage} from "./storage/GuardianStorage.sol";
 import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 import {ISafe, IOwnerManager, Enum} from "./../../interfaces/ISafe.sol";
 
 /// @title Social Recovery Module
 /// @author CANDIDE Labs
-contract SocialRecoveryModule {
+contract SocialRecoveryModule is GuardianStorage {
     string public constant NAME = "Social Recovery Module";
     string public constant VERSION = "0.0.1";
 
@@ -35,8 +35,6 @@ contract SocialRecoveryModule {
     mapping(bytes32 => mapping(address => bool)) internal confirmedHashes;
     mapping(address => uint256) internal walletsNonces;
 
-    // The guardians storage
-    IGuardianStorage internal immutable guardianStorage;
     // Recovery period
     uint256 internal immutable recoveryPeriod;
 
@@ -67,8 +65,7 @@ contract SocialRecoveryModule {
         _;
     }
 
-    constructor(IGuardianStorage _guardianStorage, uint256 _recoveryPeriod) {
-        guardianStorage = _guardianStorage;
+    constructor(uint256 _recoveryPeriod) {
         recoveryPeriod = _recoveryPeriod;
     }
 
@@ -307,41 +304,6 @@ contract SocialRecoveryModule {
     }
 
     /**
-     * @notice Lets the owner add a guardian for its wallet.
-     * @param _wallet The target wallet.
-     * @param _guardian The guardian to add.
-     * @param _threshold The new threshold that will be set after addition.
-     */
-    function addGuardianWithThreshold(address _wallet, address _guardian, uint256 _threshold) external authorized(_wallet) {
-        guardianStorage.addGuardianWithThreshold(_wallet, _guardian, _threshold);
-    }
-
-    /**
-     * @notice Lets the owner revoke a guardian from its wallet.
-     * @param _wallet The target wallet.
-     * @param _prevGuardian The previous guardian linking to the guardian in the linked list.
-     * @param _guardian The guardian to revoke.
-     * @param _threshold The new threshold that will be set after execution of revocation.
-     */
-    function revokeGuardianWithThreshold(
-        address _wallet,
-        address _prevGuardian,
-        address _guardian,
-        uint256 _threshold
-    ) external authorized(_wallet) {
-        guardianStorage.revokeGuardianWithThreshold(_wallet, _prevGuardian, _guardian, _threshold);
-    }
-
-    /**
-     * @notice Lets the owner change the guardian threshold required to initiate a recovery.
-     * @param _wallet The target wallet.
-     * @param _threshold The new threshold that will be set after execution of revocation.
-     */
-    function changeThreshold(address _wallet, uint256 _threshold) external authorized(_wallet) {
-        guardianStorage.changeThreshold(_wallet, _threshold);
-    }
-
-    /**
      * @notice Retrieves the wallet's current ongoing recovery request.
      * @param _wallet The target wallet.
      * @return request The wallet's current recovery request
@@ -390,43 +352,6 @@ contract SocialRecoveryModule {
         uint256 _nonce = nonce(_wallet);
         bytes32 recoveryHash = getRecoveryHash(_wallet, _newOwners, _newThreshold, _nonce);
         return confirmedHashes[recoveryHash][_guardian];
-    }
-
-    /**
-     * @notice Checks if an address is a guardian for a wallet.
-     * @param _wallet The target wallet.
-     * @param _guardian The address to check.
-     * @return _isGuardian `true` if the address is a guardian for the wallet otherwise `false`.
-     */
-    function isGuardian(address _wallet, address _guardian) public view returns (bool _isGuardian) {
-        return guardianStorage.isGuardian(_wallet, _guardian);
-    }
-
-    /**
-     * @notice Counts the number of active guardians for a wallet.
-     * @param _wallet The target wallet.
-     * @return _count The number of active guardians for a wallet.
-     */
-    function guardiansCount(address _wallet) public view returns (uint256 _count) {
-        return guardianStorage.guardiansCount(_wallet);
-    }
-
-    /**
-     * @dev Retrieves the wallet threshold count.
-     * @param _wallet The target wallet.
-     * @return _threshold Threshold count.
-     */
-    function threshold(address _wallet) public view returns (uint256 _threshold) {
-        return guardianStorage.threshold(_wallet);
-    }
-
-    /**
-     * @notice Get the active guardians for a wallet.
-     * @param _wallet The target wallet.
-     * @return _guardians the active guardians for a wallet.
-     */
-    function getGuardians(address _wallet) public view returns (address[] memory _guardians) {
-        return guardianStorage.getGuardians(_wallet);
     }
 
     /**

--- a/contracts/modules/social_recovery/storage/GuardianStorage.sol
+++ b/contracts/modules/social_recovery/storage/GuardianStorage.sol
@@ -30,24 +30,22 @@ contract GuardianStorage is IGuardianStorage {
 
     /**
      * @dev Throws if the caller is not an enabled module.
-     * @param _wallet The target wallet.
      */
-    modifier onlyModule(address _wallet) {
+    modifier onlyModule() {
         // solhint-disable-next-line reason-string
-        require(ISafe(payable(_wallet)).isModuleEnabled(msg.sender), "GS: method only callable by an enabled module");
+        require(ISafe(payable(msg.sender)).isModuleEnabled(address(this)), "GS: method only callable by an enabled module");
         _;
     }
 
     /**
      * @dev Lets an authorised module add a guardian to a wallet and change the threshold.
-     * @param _wallet The target wallet.
      * @param _guardian The guardian to add.
      */
-    function addGuardianWithThreshold(address _wallet, address _guardian, uint256 _threshold) external onlyModule(_wallet) {
+    function addGuardianWithThreshold(address _guardian, uint256 _threshold) external onlyModule() {
         require(_threshold > 0, "GS: threshold cannot be 0");
-        require(_guardian != address(0) && _guardian != SENTINEL_GUARDIANS && _guardian != _wallet, "GS: invalid guardian");
-        require(!ISafe(payable(_wallet)).isOwner(_guardian), "GS: guardian cannot be an owner");
-        GuardianStorageEntry storage entry = entries[_wallet];
+        require(_guardian != address(0) && _guardian != SENTINEL_GUARDIANS && _guardian != msg.sender, "GS: invalid guardian");
+        require(!ISafe(payable(msg.sender)).isOwner(_guardian), "GS: guardian cannot be an owner");
+        GuardianStorageEntry storage entry = entries[msg.sender];
         require(entry.guardians[_guardian] == address(0), "GS: duplicate guardian");
         if (entry.count == 0){
             entry.guardians[SENTINEL_GUARDIANS] = _guardian;
@@ -57,39 +55,37 @@ contract GuardianStorage is IGuardianStorage {
             entry.guardians[SENTINEL_GUARDIANS] = _guardian;
         }
         entry.count++;
-        emit GuardianAdded(_wallet, _guardian);
+        emit GuardianAdded(msg.sender, _guardian);
         if (entry.threshold != _threshold){
-            _changeThreshold(_wallet, _threshold);
+            _changeThreshold(msg.sender, _threshold);
         }
     }
 
     /**
      * @dev Lets an authorised module revoke a guardian from a wallet and change the threshold.
-     * @param _wallet The target wallet.
      * @param _prevGuardian Guardian that pointed to the guardian to be removed in the linked list
      * @param _guardian The guardian to revoke.
      */
-    function revokeGuardianWithThreshold(address _wallet, address _prevGuardian, address _guardian, uint256 _threshold) external onlyModule(_wallet) {
-        GuardianStorageEntry storage entry = entries[_wallet];
+    function revokeGuardianWithThreshold(address _prevGuardian, address _guardian, uint256 _threshold) external onlyModule() {
+        GuardianStorageEntry storage entry = entries[msg.sender];
         require(_guardian != address(0) && _guardian != SENTINEL_GUARDIANS, "GS: invalid guardian");
         require(entry.guardians[_prevGuardian] == _guardian, "GS: invalid previous guardian");
         require(entry.count - 1 >= _threshold, "GS: invalid threshold");
         entry.guardians[_prevGuardian] = entry.guardians[_guardian];
         entry.guardians[_guardian] = address(0);
         entry.count--;
-        emit GuardianRevoked(_wallet, _guardian);
+        emit GuardianRevoked(msg.sender, _guardian);
         if (entry.threshold != _threshold){
-            _changeThreshold(_wallet, _threshold);
+            _changeThreshold(msg.sender, _threshold);
         }
     }
 
     /**
      * @dev Allows to update the number of required confirmations by guardians.
-     * @param _wallet The target wallet.
      * @param _threshold New threshold.
      */
-    function changeThreshold(address _wallet, uint256 _threshold) external onlyModule(_wallet) {
-        _changeThreshold(_wallet, _threshold);
+    function changeThreshold(uint256 _threshold) external onlyModule(){
+        _changeThreshold(msg.sender, _threshold);
     }
 
     function _changeThreshold(address _wallet, uint256 _threshold) internal {

--- a/contracts/modules/social_recovery/storage/GuardianStorage.sol
+++ b/contracts/modules/social_recovery/storage/GuardianStorage.sol
@@ -31,9 +31,9 @@ contract GuardianStorage is IGuardianStorage {
     /**
      * @dev Throws if the caller is not an enabled module.
      */
-    modifier onlyModule() {
+    modifier onlyWhenModuleIsEnabled() {
         // solhint-disable-next-line reason-string
-        require(ISafe(payable(msg.sender)).isModuleEnabled(address(this)), "GS: method only callable by an enabled module");
+        require(ISafe(payable(msg.sender)).isModuleEnabled(address(this)), "GS: method only callable when module is enabled");
         _;
     }
 
@@ -41,7 +41,7 @@ contract GuardianStorage is IGuardianStorage {
      * @dev Lets an authorised module add a guardian to a wallet and change the threshold.
      * @param _guardian The guardian to add.
      */
-    function addGuardianWithThreshold(address _guardian, uint256 _threshold) external onlyModule() {
+    function addGuardianWithThreshold(address _guardian, uint256 _threshold) external onlyWhenModuleIsEnabled() {
         require(_threshold > 0, "GS: threshold cannot be 0");
         require(_guardian != address(0) && _guardian != SENTINEL_GUARDIANS && _guardian != msg.sender, "GS: invalid guardian");
         require(!ISafe(payable(msg.sender)).isOwner(_guardian), "GS: guardian cannot be an owner");
@@ -66,7 +66,7 @@ contract GuardianStorage is IGuardianStorage {
      * @param _prevGuardian Guardian that pointed to the guardian to be removed in the linked list
      * @param _guardian The guardian to revoke.
      */
-    function revokeGuardianWithThreshold(address _prevGuardian, address _guardian, uint256 _threshold) external onlyModule() {
+    function revokeGuardianWithThreshold(address _prevGuardian, address _guardian, uint256 _threshold) external onlyWhenModuleIsEnabled() {
         GuardianStorageEntry storage entry = entries[msg.sender];
         require(_guardian != address(0) && _guardian != SENTINEL_GUARDIANS, "GS: invalid guardian");
         require(entry.guardians[_prevGuardian] == _guardian, "GS: invalid previous guardian");
@@ -84,7 +84,7 @@ contract GuardianStorage is IGuardianStorage {
      * @dev Allows to update the number of required confirmations by guardians.
      * @param _threshold New threshold.
      */
-    function changeThreshold(uint256 _threshold) external onlyModule(){
+    function changeThreshold(uint256 _threshold) external onlyWhenModuleIsEnabled(){
         _changeThreshold(msg.sender, _threshold);
     }
 

--- a/contracts/modules/social_recovery/storage/GuardianStorage.sol
+++ b/contracts/modules/social_recovery/storage/GuardianStorage.sol
@@ -84,7 +84,7 @@ contract GuardianStorage is IGuardianStorage {
      * @dev Allows to update the number of required confirmations by guardians.
      * @param _threshold New threshold.
      */
-    function changeThreshold(uint256 _threshold) external onlyWhenModuleIsEnabled(){
+    function changeThreshold(uint256 _threshold) external onlyWhenModuleIsEnabled() {
         _changeThreshold(msg.sender, _threshold);
     }
 

--- a/contracts/modules/social_recovery/storage/IGuardianStorage.sol
+++ b/contracts/modules/social_recovery/storage/IGuardianStorage.sol
@@ -4,25 +4,22 @@ pragma solidity >=0.8.12 <0.9.0;
 interface IGuardianStorage {
     /**
      * @dev Lets an authorised module add a guardian to a wallet and change the threshold.
-     * @param _wallet The target wallet.
      * @param _guardian The guardian to add.
      */
-    function addGuardianWithThreshold(address _wallet, address _guardian, uint256 _threshold) external;
+    function addGuardianWithThreshold(address _guardian, uint256 _threshold) external;
 
     /**
      * @dev Lets an authorised module revoke a guardian from a wallet and change the threshold.
-     * @param _wallet The target wallet.
      * @param _prevGuardian Guardian that pointed to the guardian to be removed in the linked list
      * @param _guardian The guardian to revoke.
      */
-    function revokeGuardianWithThreshold(address _wallet, address _prevGuardian, address _guardian, uint256 _threshold) external;
+    function revokeGuardianWithThreshold(address _prevGuardian, address _guardian, uint256 _threshold) external;
 
     /**
      * @dev Allows to update the number of required confirmations by guardians.
-     * @param _wallet The target wallet.
      * @param _threshold New threshold.
      */
-    function changeThreshold(address _wallet, uint256 _threshold) external;
+    function changeThreshold(uint256 _threshold) external;
 
     /**
      * @dev Checks if an account is a guardian for a wallet.

--- a/test/GuardianStorage.spec.ts
+++ b/test/GuardianStorage.spec.ts
@@ -51,7 +51,7 @@ describe("GuardianStorage", async () => {
       await account.exec(account.target, 0, removeModuleData);
       //
       const data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [guardian1.address, 1]);
-      await expect(account.exec(socialRecoveryModule.target, 0, data)).to.be.revertedWith("GS: method only callable by an enabled module");
+      await expect(account.exec(socialRecoveryModule.target, 0, data)).to.be.revertedWith("GS: method only callable when module is enabled");
     });
     it("should not allow adding zero address as guardian", async () => {
       const { account, socialRecoveryModule } = await loadFixture(setupTests);
@@ -131,7 +131,7 @@ describe("GuardianStorage", async () => {
       await account.exec(account.target, 0, removeModuleData);
       //
       const data = socialRecoveryModule.interface.encodeFunctionData("revokeGuardianWithThreshold", [SENTINEL_ADDRESS, guardian1.address, 0]);
-      await expect(account.exec(socialRecoveryModule.target, 0, data)).to.be.revertedWith("GS: method only callable by an enabled module");
+      await expect(account.exec(socialRecoveryModule.target, 0, data)).to.be.revertedWith("GS: method only callable when module is enabled");
     });
     it("can not revoke non guardians", async () => {
       const { account, socialRecoveryModule } = await loadFixture(setupTests);
@@ -236,7 +236,7 @@ describe("GuardianStorage", async () => {
       await account.exec(account.target, 0, removeModuleData);
       //
       const data = socialRecoveryModule.interface.encodeFunctionData("changeThreshold", [1]);
-      await expect(account.exec(socialRecoveryModule.target, 0, data)).to.be.revertedWith("GS: method only callable by an enabled module");
+      await expect(account.exec(socialRecoveryModule.target, 0, data)).to.be.revertedWith("GS: method only callable when module is enabled");
     });
     it("reverts if threshold is higher than guardians count", async () => {
       const { account, socialRecoveryModule } = await loadFixture(setupTests);

--- a/test/GuardianStorage.spec.ts
+++ b/test/GuardianStorage.spec.ts
@@ -21,13 +21,13 @@ describe("GuardianStorage", async () => {
     const guardianStorage = await ethers.deployContract("GuardianStorage", [], { signer: deployer });
     const socialRecoveryModule = await ethers.deployContract(
       "SocialRecoveryModule",
-      [await guardianStorage.getAddress(), 3600],
+      [3600],
       { signer: deployer },
     );
     const account = await hre.ethers.deployContract("TestExecutor", [], { signer: deployer });
     await account.testSetup([owner1.address, owner2.address], 1, ADDRESS_ZERO, [await socialRecoveryModule.getAddress()]);
     //
-    return { account, socialRecoveryModule, guardianStorage };
+    return { account, socialRecoveryModule, guardianStorage: socialRecoveryModule };
   }
 
   async function _addGuardianWithThreshold(
@@ -36,17 +36,12 @@ describe("GuardianStorage", async () => {
     guardian: string,
     threshold: number,
   ) {
-    const data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [account.target, guardian, threshold]);
+    const data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [guardian, threshold]);
     await account.exec(socialRecoveryModule.target, 0, data);
   }
 
 
   describe("Adding Guardians", async () => {
-    it("should not allow adding guardian if not authorized", async () => {
-      const { account, socialRecoveryModule } = await loadFixture(setupTests);
-      const data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [account.target, guardian1.address, 1]);
-      await expect(deployer.sendTransaction({ to: socialRecoveryModule.target, data: data })).to.be.revertedWith("SM: unauthorized");
-    });
     it("should not allow adding guardian if SocialRecoveryModule is not an enabled module", async () => {
       const { account, socialRecoveryModule } = await loadFixture(setupTests);
       const removeModuleData = account.interface.encodeFunctionData("disableModule", [
@@ -55,58 +50,58 @@ describe("GuardianStorage", async () => {
       ]);
       await account.exec(account.target, 0, removeModuleData);
       //
-      const data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [account.target, guardian1.address, 1]);
+      const data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [guardian1.address, 1]);
       await expect(account.exec(socialRecoveryModule.target, 0, data)).to.be.revertedWith("GS: method only callable by an enabled module");
     });
     it("should not allow adding zero address as guardian", async () => {
       const { account, socialRecoveryModule } = await loadFixture(setupTests);
-      const data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [account.target, ADDRESS_ZERO, 1]);
+      const data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [ADDRESS_ZERO, 1]);
       await expect(account.exec(socialRecoveryModule.target, 0, data)).to.be.revertedWith("GS: invalid guardian");
     });
     it("should not allow adding sentinel address as guardian", async () => {
       const { account, socialRecoveryModule } = await loadFixture(setupTests);
-      const data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [account.target, SENTINEL_ADDRESS, 1]);
+      const data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [SENTINEL_ADDRESS, 1]);
       await expect(account.exec(socialRecoveryModule.target, 0, data)).to.be.revertedWith("GS: invalid guardian");
     });
     it("should not allow adding itself (wallet) as guardian", async () => {
       const { account, socialRecoveryModule } = await loadFixture(setupTests);
-      const data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [account.target, account.target, 1]);
+      const data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [account.target, 1]);
       await expect(account.exec(socialRecoveryModule.target, 0, data)).to.be.revertedWith("GS: invalid guardian");
     });
     it("should not allow adding the wallet owners as guardians", async () => {
       const { account, socialRecoveryModule } = await loadFixture(setupTests);
-      const data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [account.target, owner1.address, 1]);
+      const data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [owner1.address, 1]);
       await expect(account.exec(socialRecoveryModule.target, 0, data)).to.be.revertedWith("GS: guardian cannot be an owner");
     });
     it("should not allow adding guardian with 0 threshold", async () => {
       const { account, socialRecoveryModule } = await loadFixture(setupTests);
-      const data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [account.target, guardian1.address, 0]);
+      const data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [guardian1.address, 0]);
       await expect(account.exec(socialRecoveryModule.target, 0, data)).to.be.revertedWith("GS: threshold cannot be 0");
     });
     it("should not allow adding x guardians with threshold >x", async () => {
       const { account, socialRecoveryModule } = await loadFixture(setupTests);
-      const data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [account.target, guardian1.address, 2]);
+      const data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [guardian1.address, 2]);
       await expect(account.exec(socialRecoveryModule.target, 0, data)).to.be.revertedWith(
         "GS: threshold must be lower or equal to guardians count",
       );
     });
     it("should not allow adding duplicate guardians", async () => {
       const { account, socialRecoveryModule } = await loadFixture(setupTests);
-      let data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [account.target, guardian1.address, 1]);
+      let data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [guardian1.address, 1]);
       await account.exec(socialRecoveryModule.target, 0, data);
-      data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [account.target, guardian1.address, 1]);
+      data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [guardian1.address, 1]);
       await expect(account.exec(socialRecoveryModule.target, 0, data)).to.be.revertedWith("GS: duplicate guardian");
     });
     it("should allow adding guardians with new threshold", async () => {
       const { account, socialRecoveryModule, guardianStorage } = await loadFixture(setupTests);
       expect(await socialRecoveryModule.isGuardian(account.target, guardian1.address)).to.eq(false);
       expect(await socialRecoveryModule.getGuardians(account.target)).to.deep.eq([]);
-      let data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [account.target, guardian1.address, 1]);
+      let data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [guardian1.address, 1]);
       await expect(account.exec(socialRecoveryModule.target, 0, data)).to.emit(guardianStorage, "GuardianAdded").and.to.emit(guardianStorage, "ChangedThreshold");
       expect(await socialRecoveryModule.isGuardian(account.target, guardian1.address)).to.eq(true);
       expect(await socialRecoveryModule.threshold(account.target)).to.eq(1);
       expect(await socialRecoveryModule.guardiansCount(account.target)).to.eq(1);
-      data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [account.target, guardian2.address, 2]);
+      data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [guardian2.address, 2]);
       await expect(account.exec(socialRecoveryModule.target, 0, data)).to.emit(guardianStorage, "GuardianAdded").and.to.emit(guardianStorage, "ChangedThreshold");
       expect(await socialRecoveryModule.isGuardian(account.target, guardian1.address)).to.eq(true);
       expect(await socialRecoveryModule.isGuardian(account.target, guardian2.address)).to.eq(true);
@@ -115,9 +110,9 @@ describe("GuardianStorage", async () => {
     });
     it("should allow adding guardians with same threshold", async () => {
       const { account, socialRecoveryModule, guardianStorage } = await loadFixture(setupTests);
-      let data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [account.target, guardian1.address, 1]);
+      let data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [guardian1.address, 1]);
       await expect(account.exec(socialRecoveryModule.target, 0, data)).to.emit(guardianStorage, "GuardianAdded").and.to.emit(guardianStorage, "ChangedThreshold");
-      data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [account.target, guardian2.address, 1]);
+      data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [guardian2.address, 1]);
       await expect(account.exec(socialRecoveryModule.target, 0, data)).to.emit(guardianStorage, "GuardianAdded").and.to.not.emit(guardianStorage, "ChangedThreshold");
       expect(await socialRecoveryModule.isGuardian(account.target, guardian1.address)).to.eq(true);
       expect(await socialRecoveryModule.isGuardian(account.target, guardian2.address)).to.eq(true);
@@ -126,16 +121,6 @@ describe("GuardianStorage", async () => {
     });
   });
   describe("Revoking Guardians", async () => {
-    it("should not allow revoking guardian if not authorized", async () => {
-      const { account, socialRecoveryModule } = await loadFixture(setupTests);
-      const data = socialRecoveryModule.interface.encodeFunctionData("revokeGuardianWithThreshold", [
-        account.target,
-        SENTINEL_ADDRESS,
-        guardian1.address,
-        0,
-      ]);
-      await expect(deployer.sendTransaction({ to: socialRecoveryModule.target, data: data })).to.be.revertedWith("SM: unauthorized");
-    });
     it("should not allow revoking guardian if SocialRecoveryModule is not an enabled module", async () => {
       const { account, socialRecoveryModule } = await loadFixture(setupTests);
       await _addGuardianWithThreshold(socialRecoveryModule, account, guardian1.address, 1);
@@ -145,13 +130,12 @@ describe("GuardianStorage", async () => {
       ]);
       await account.exec(account.target, 0, removeModuleData);
       //
-      const data = socialRecoveryModule.interface.encodeFunctionData("revokeGuardianWithThreshold", [account.target, SENTINEL_ADDRESS, guardian1.address, 0]);
+      const data = socialRecoveryModule.interface.encodeFunctionData("revokeGuardianWithThreshold", [SENTINEL_ADDRESS, guardian1.address, 0]);
       await expect(account.exec(socialRecoveryModule.target, 0, data)).to.be.revertedWith("GS: method only callable by an enabled module");
     });
     it("can not revoke non guardians", async () => {
       const { account, socialRecoveryModule } = await loadFixture(setupTests);
       const data = socialRecoveryModule.interface.encodeFunctionData("revokeGuardianWithThreshold", [
-        account.target,
         SENTINEL_ADDRESS,
         guardian1.address,
         0,
@@ -162,7 +146,6 @@ describe("GuardianStorage", async () => {
       const { account, socialRecoveryModule } = await loadFixture(setupTests);
       //
       const data = socialRecoveryModule.interface.encodeFunctionData("revokeGuardianWithThreshold", [
-        account.target,
         SENTINEL_ADDRESS,
         ADDRESS_ZERO,
         0,
@@ -174,7 +157,6 @@ describe("GuardianStorage", async () => {
       const { account, socialRecoveryModule } = await loadFixture(setupTests);
       //
       const data = socialRecoveryModule.interface.encodeFunctionData("revokeGuardianWithThreshold", [
-        account.target,
         SENTINEL_ADDRESS,
         SENTINEL_ADDRESS,
         0,
@@ -186,7 +168,6 @@ describe("GuardianStorage", async () => {
       const { account, socialRecoveryModule } = await loadFixture(setupTests);
       await _addGuardianWithThreshold(socialRecoveryModule, account, guardian1.address, 1);
       const data = socialRecoveryModule.interface.encodeFunctionData("revokeGuardianWithThreshold", [
-        account.target,
         SENTINEL_ADDRESS,
         guardian1.address,
         1,
@@ -198,7 +179,6 @@ describe("GuardianStorage", async () => {
       await _addGuardianWithThreshold(socialRecoveryModule, account, guardian1.address, 1);
       await _addGuardianWithThreshold(socialRecoveryModule, account, guardian2.address, 2);
       const data = socialRecoveryModule.interface.encodeFunctionData("revokeGuardianWithThreshold", [
-        account.target,
         SENTINEL_ADDRESS,
         guardian2.address,
         0,
@@ -209,7 +189,6 @@ describe("GuardianStorage", async () => {
       const { account, socialRecoveryModule } = await loadFixture(setupTests);
       await _addGuardianWithThreshold(socialRecoveryModule, account, guardian1.address, 1);
       const data = socialRecoveryModule.interface.encodeFunctionData("revokeGuardianWithThreshold", [
-        account.target,
         owner1.address,
         guardian1.address,
         0,
@@ -221,7 +200,6 @@ describe("GuardianStorage", async () => {
       await _addGuardianWithThreshold(socialRecoveryModule, account, guardian1.address, 1);
       await _addGuardianWithThreshold(socialRecoveryModule, account, guardian2.address, 1);
       const data = socialRecoveryModule.interface.encodeFunctionData("revokeGuardianWithThreshold", [
-        account.target,
         guardian2.address,
         guardian1.address,
         1,
@@ -236,7 +214,6 @@ describe("GuardianStorage", async () => {
       await _addGuardianWithThreshold(socialRecoveryModule, account, guardian1.address, 1);
       await _addGuardianWithThreshold(socialRecoveryModule, account, guardian2.address, 2);
       const data = socialRecoveryModule.interface.encodeFunctionData("revokeGuardianWithThreshold", [
-        account.target,
         guardian2.address,
         guardian1.address,
         1,
@@ -248,13 +225,6 @@ describe("GuardianStorage", async () => {
     });
   });
   describe("Changing Threshold", async () => {
-    it("reverts if not authorized", async () => {
-      const { account, socialRecoveryModule } = await loadFixture(setupTests);
-      await _addGuardianWithThreshold(socialRecoveryModule, account, guardian1.address, 1);
-      await _addGuardianWithThreshold(socialRecoveryModule, account, guardian2.address, 2);
-      const data = socialRecoveryModule.interface.encodeFunctionData("changeThreshold", [account.target, 1]);
-      await expect(deployer.sendTransaction({ to: socialRecoveryModule.target, data })).to.be.revertedWith("SM: unauthorized");
-    });
     it("should not allow changing threshold if SocialRecoveryModule is not an enabled module", async () => {
       const { account, socialRecoveryModule } = await loadFixture(setupTests);
       await _addGuardianWithThreshold(socialRecoveryModule, account, guardian1.address, 1);
@@ -265,7 +235,7 @@ describe("GuardianStorage", async () => {
       ]);
       await account.exec(account.target, 0, removeModuleData);
       //
-      const data = socialRecoveryModule.interface.encodeFunctionData("changeThreshold", [account.target, 1]);
+      const data = socialRecoveryModule.interface.encodeFunctionData("changeThreshold", [1]);
       await expect(account.exec(socialRecoveryModule.target, 0, data)).to.be.revertedWith("GS: method only callable by an enabled module");
     });
     it("reverts if threshold is higher than guardians count", async () => {
@@ -273,7 +243,7 @@ describe("GuardianStorage", async () => {
       await _addGuardianWithThreshold(socialRecoveryModule, account, guardian1.address, 1);
       await _addGuardianWithThreshold(socialRecoveryModule, account, guardian2.address, 2);
       await _addGuardianWithThreshold(socialRecoveryModule, account, guardian3.address, 2);
-      const data = socialRecoveryModule.interface.encodeFunctionData("changeThreshold", [account.target, 4]);
+      const data = socialRecoveryModule.interface.encodeFunctionData("changeThreshold", [4]);
       await expect(account.exec(socialRecoveryModule.target, 0, data)).to.be.revertedWith(
         "GS: threshold must be lower or equal to guardians count",
       );
@@ -283,13 +253,13 @@ describe("GuardianStorage", async () => {
       await _addGuardianWithThreshold(socialRecoveryModule, account, guardian1.address, 1);
       await _addGuardianWithThreshold(socialRecoveryModule, account, guardian2.address, 2);
       await _addGuardianWithThreshold(socialRecoveryModule, account, guardian3.address, 2);
-      const data = socialRecoveryModule.interface.encodeFunctionData("changeThreshold", [account.target, 0]);
+      const data = socialRecoveryModule.interface.encodeFunctionData("changeThreshold", [0]);
       await expect(account.exec(socialRecoveryModule.target, 0, data)).to.be.revertedWith("GS: threshold cannot be 0");
     });
     it("allows changing threshold to 0 even with no guardians", async () => {
       const { account, socialRecoveryModule, guardianStorage } = await loadFixture(setupTests);
       expect(await socialRecoveryModule.threshold(account.target)).to.eq(0);
-      const data = socialRecoveryModule.interface.encodeFunctionData("changeThreshold", [account.target, 0]);
+      const data = socialRecoveryModule.interface.encodeFunctionData("changeThreshold", [0]);
       await expect(account.exec(socialRecoveryModule.target, 0, data)).to.emit(guardianStorage, "ChangedThreshold");
       expect(await socialRecoveryModule.threshold(account.target)).to.eq(0);
     });
@@ -298,7 +268,7 @@ describe("GuardianStorage", async () => {
       await _addGuardianWithThreshold(socialRecoveryModule, account, guardian1.address, 1);
       await _addGuardianWithThreshold(socialRecoveryModule, account, guardian2.address, 1);
       expect(await socialRecoveryModule.threshold(account.target)).to.eq(1);
-      const data = socialRecoveryModule.interface.encodeFunctionData("changeThreshold", [account.target, 2]);
+      const data = socialRecoveryModule.interface.encodeFunctionData("changeThreshold", [2]);
       await expect(account.exec(socialRecoveryModule.target, 0, data)).to.emit(guardianStorage, "ChangedThreshold");
       expect(await socialRecoveryModule.threshold(account.target)).to.eq(2);
     });

--- a/test/SocialRecoveryModule.spec.ts
+++ b/test/SocialRecoveryModule.spec.ts
@@ -543,14 +543,9 @@ describe("SocialRecoveryModule", async () => {
     });
   });
   describe("Cancel Recovery", async () => {
-    it("reverts if not authorized", async () => {
-      const { account, socialRecoveryModule } = await loadFixture(setupTests);
-      const data = socialRecoveryModule.interface.encodeFunctionData("cancelRecovery", [account.target]);
-      await expect(deployer.sendTransaction({ to: socialRecoveryModule.target, data })).to.be.revertedWith("SM: unauthorized");
-    });
     it("reverts if there's no ongoing recovery", async () => {
       const { account, socialRecoveryModule } = await loadFixture(setupTests);
-      const data = socialRecoveryModule.interface.encodeFunctionData("cancelRecovery", [account.target]);
+      const data = socialRecoveryModule.interface.encodeFunctionData("cancelRecovery");
       await expect(account.exec(socialRecoveryModule.target, 0, data)).to.be.revertedWith("SM: no ongoing recovery");
     });
     it("allows cancelling an ongoing recovery", async () => {
@@ -559,7 +554,7 @@ describe("SocialRecoveryModule", async () => {
       await confirmRecovery(socialRecoveryModule, account, [newOwner1.address], 1, [guardian1]);
       let data = socialRecoveryModule.interface.encodeFunctionData("executeRecovery", [account.target, [newOwner1.address], 1]);
       await guardian1.sendTransaction({ to: socialRecoveryModule.target, data });
-      data = socialRecoveryModule.interface.encodeFunctionData("cancelRecovery", [account.target]);
+      data = socialRecoveryModule.interface.encodeFunctionData("cancelRecovery");
       await expect(account.exec(socialRecoveryModule.target, 0, data)).to.emit(socialRecoveryModule, "RecoveryCanceled");
       const recoveryRequest = await socialRecoveryModule.getRecoveryRequest(account.target);
       expect(recoveryRequest.executeAfter).to.eq(0);

--- a/test/SocialRecoveryModule.spec.ts
+++ b/test/SocialRecoveryModule.spec.ts
@@ -24,7 +24,7 @@ describe("SocialRecoveryModule", async () => {
     const guardianStorage = await ethers.deployContract("GuardianStorage", [], { signer: deployer });
     const socialRecoveryModule = await ethers.deployContract(
       "SocialRecoveryModule",
-      [await guardianStorage.getAddress(), 3600],
+      [3600],
       { signer: deployer },
     );
     const account = await hre.ethers.deployContract("TestExecutor", [], { signer: deployer });
@@ -39,7 +39,7 @@ describe("SocialRecoveryModule", async () => {
     guardian: string,
     threshold: number,
   ) {
-    const data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [account.target, guardian, threshold]);
+    const data = socialRecoveryModule.interface.encodeFunctionData("addGuardianWithThreshold", [guardian, threshold]);
     await account.exec(socialRecoveryModule.target, 0, data);
   }
 


### PR DESCRIPTION
This PR changes the design of how the guardians are stored.

Prior to this change, the guardians were stored in a separate contract `GuardianStorage`. The `GuardianStorage` address was then passed as a constructor parameter to `SocialRecoveryModule` which could then make changes to the list on request by the user. So, the recovery functionality was achieved by having two contracts and thus, two storages.

As a side effect, it was initially brought to light that any other module can also modify the list of Guardians in `GuardianStorage` and was not write-restricted only to `SocialRecoveryModule`. Any other enabled module on a Safe could change this list.
See: https://github.com/5afe/CandideWalletContracts/blob/870f82d3c4d286b3fd9241c6479c9472d7d73fc6/contracts/modules/social_recovery/storage/GuardianStorage.sol#L35

The initial argument for accepting this behavior was that any malicious module can:
1- Change ownership of the account
2- Steal all account's funds
3- Execute any arbitrary function of the `SocialRecoveryModule` impersonating the owner
Thus, it did not violate any security assumptions.

Also, allowing the guardian list to be edited by any module allows upgradability of `SocialRecoveryModule` without having to migrate the list of guardians.

But, later auditing partner also reported the same behavior as an issue with the argument:

- There should be a distinction between malicious modules (or any modules that can perform arbitrary operations) and modules that are limited to do these things by their implementation. These "well behaving" modules will effectively gain more privileges than they actually need.
- It opens a new attack vector and violates least privilege principle.

After internal discussion, we concluded that allowing any module to modify the guardians list should not be permitted and this PR reflects the same.

In this PR, `SocialRecoveryModule` inherits `GuardianStorage` so that there is only 1 contract involved in recovery functionality. By making this change and removing `onlyModule` modifier, and other changes in the code (removing `_wallet` as a parameter in some functions) now allows only wallet i.e. `msg.sender` to change the guardians.

This also simplifies the design of the recovery functionality and enforces to use storage space of a single contract i.e. `SocialRecoveryModule`.

Other changes in PR include:
- Fixes to files related to formal verification
- Removing duplicated code which is now not needed
- Remove redundant parameter `_wallet` in some functions