### PR TITLE
Anyone Can Finalize Recovery

### DIFF
--- a/certora/specs/SocialRecoveryModule.spec
+++ b/certora/specs/SocialRecoveryModule.spec
@@ -436,3 +436,25 @@ rule canFinalizeRecoveryOnlyAfterDelayPeriod(env e) {
 
     assert success => require_uint64(e.block.timestamp) >= recoveryTimestamp, "Recovery finalized before delay period";
 }
+
+// Recovery can be finalized by anyone after the delay period is over.
+rule anyoneCanFinalizeRecovery(env e) {
+    uint64 executeAfter = currentContract.recoveryRequests[safeContract].executeAfter;
+
+    requireInitiatedRecovery(safeContract);
+
+    require e.msg.value == 0;
+    // require require_uint64(e.block.timestamp) >= currentContract.recoveryRequests[safeContract].executeAfter;
+    require safeContract.getOwners().length > 0;
+    // This is to ensure that new owners are not guardians. We cannot use `isGuardian` due to use of quantifiers.
+    require forall uint256 i.
+        !(currentContract.recoveryRequests[safeContract].newOwners[i] != SENTINEL() &&
+        currentContract.entries[safeContract].guardians[currentContract.recoveryRequests[safeContract].newOwners[i]] != 0);
+
+    currentContract.finalizeRecovery@withrevert(e, safeContract);
+
+    bool success = !lastReverted;
+
+    assert (success && require_uint64(e.block.timestamp) >= executeAfter) ||
+        (!success && require_uint64(e.block.timestamp) < executeAfter);
+}

--- a/certora/specs/SocialRecoveryModule.spec
+++ b/certora/specs/SocialRecoveryModule.spec
@@ -437,16 +437,15 @@ rule canFinalizeRecoveryOnlyAfterDelayPeriod(env e) {
     assert success => require_uint64(e.block.timestamp) >= recoveryTimestamp, "Recovery finalized before delay period";
 }
 
-// Recovery can be finalized by anyone after the delay period is over.
+// Recovery can be finalized by anyone. But the success of the transaction depends on the delay period.
 rule anyoneCanFinalizeRecovery(env e) {
     uint64 executeAfter = currentContract.recoveryRequests[safeContract].executeAfter;
 
     requireInitiatedRecovery(safeContract);
 
     require e.msg.value == 0;
-    // require require_uint64(e.block.timestamp) >= currentContract.recoveryRequests[safeContract].executeAfter;
     require safeContract.getOwners().length > 0;
-    // This is to ensure that new owners are not guardians. We cannot use `isGuardian` due to use of quantifiers.
+    // The contract doesn't allow guardians as new owners, hence we require it. We cannot use `isGuardian` due to use of quantifiers.
     require forall uint256 i.
         !(currentContract.recoveryRequests[safeContract].newOwners[i] != SENTINEL() &&
         currentContract.entries[safeContract].guardians[currentContract.recoveryRequests[safeContract].newOwners[i]] != 0);


### PR DESCRIPTION
Fixes #7 

This PR merges the `canFinalizeRecoveryOnlyAfterDelayPeriod` rule which checks that a call to the `finalizeRecovery` can only succeed after the delay period with an additional check to ensure that if reverted, what are the conditions possible.