### PR TITLE
Invalidate `nonce`

### DIFF
--- a/.github/workflows/test_contracts.yml
+++ b/.github/workflows/test_contracts.yml
@@ -1,0 +1,27 @@
+name: test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: npm
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run Tests
+        run: yarn test

--- a/certora/harnesses/SocialRecoveryModuleHarness.sol
+++ b/certora/harnesses/SocialRecoveryModuleHarness.sol
@@ -31,4 +31,28 @@ contract SocialRecoveryModuleHarness is SocialRecoveryModule {
             count++;
         }
     }
+
+    /**
+     * @notice Retrieves the guardian approval count for this particular recovery request at particular nonce.
+     * @param _wallet The target wallet.
+     * @param _newOwners The new owners' addressess.
+     * @param _newThreshold The new threshold for the safe.
+     * @param _nonce The nonce of the recovery request.
+     * @return approvalCount The wallet's current recovery request
+     */
+    function getRecoveryApprovalsWithNonce(
+        address _wallet,
+        address[] calldata _newOwners,
+        uint256 _newThreshold,
+        uint256 _nonce
+    ) public view returns (uint256 approvalCount) {
+        bytes32 recoveryHash = getRecoveryHash(_wallet, _newOwners, _newThreshold, _nonce);
+        address[] memory guardians = getGuardians(_wallet);
+        approvalCount = 0;
+        for (uint256 i = 0; i < guardians.length; i++) {
+            if (confirmedHashes[recoveryHash][guardians[i]]) {
+                approvalCount++;
+            }
+        }
+    }    
 }

--- a/contracts/modules/social_recovery/SocialRecoveryModule.sol
+++ b/contracts/modules/social_recovery/SocialRecoveryModule.sol
@@ -296,7 +296,10 @@ contract SocialRecoveryModule is GuardianStorage {
     }
 
     /**
-     * @notice Invalidates the wallet's nonce to prevent replay attacks.
+     * @notice Invalidates the wallet's nonce. This will invalidate existing
+     * recovery confirmations from guardians and can be used either to cancel
+     * the process of collecting confirmations from guardians or when rotating
+     * the guardian configuration to prevent "shadow" confirmations.
      * @dev This function should only be used between initiation and execution of a recovery.
      */
     function invalidateNonce() external {

--- a/contracts/modules/social_recovery/SocialRecoveryModule.sol
+++ b/contracts/modules/social_recovery/SocialRecoveryModule.sol
@@ -48,6 +48,7 @@ contract SocialRecoveryModule is GuardianStorage {
     );
     event RecoveryFinalized(address indexed wallet, address[] indexed newOwners, uint256 newThreshold, uint256 nonce);
     event RecoveryCanceled(address indexed wallet, uint256 nonce);
+    event NonceInvalidated(address indexed wallet, uint256 nonce);
 
     /**
      * @notice Throws if there is no ongoing recovery request.
@@ -292,6 +293,15 @@ contract SocialRecoveryModule is GuardianStorage {
     function cancelRecovery() external whenRecovery(msg.sender) {
         delete recoveryRequests[msg.sender];
         emit RecoveryCanceled(msg.sender, walletsNonces[msg.sender] - 1);
+    }
+
+    /**
+     * @notice Invalidates the wallet's nonce to prevent replay attacks.
+     * @dev This function should only be used between initiation and execution of a recovery.
+     */
+    function invalidateNonce() external {
+        walletsNonces[msg.sender]++;
+        emit NonceInvalidated(msg.sender, walletsNonces[msg.sender] - 1);
     }
 
     /**


### PR DESCRIPTION
This PR adds an extra function called `invalidateNonce(...)` based on the recommendation from the audit team to invalidate a particular recovery process. It could be used in two ways:
- Assuming the owner lost access to the Safe, the owner requests a guardian for recovery initiation. Once the recovery initiation started, the owner realized that the access was not actually lost, thus to invalidate the current initiation (not execution, for that owner can use `cancelRecovery(...)`), the owner can actually call the `invalidateNonce(...)`.
- As a best practice to invalidate any `confirmedHashes[...][...]` from a guardian which is soon to be removed.

Also added:
- a test to check if execution fails in the case of an invalidated nonce.
- run test in CI.
- FV to check if invalidating a nonce cancels an execution of recovery.