### PR TITLE
Add a rule that verifies signature validity for confirming the recovery

### DIFF
--- a/.github/workflows/certora_recovery.yml
+++ b/.github/workflows/certora_recovery.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rule: ['SocialRecoveryModule', "GuardianStorage"]
+        rule: ['SocialRecoveryModule', 'GuardianStorage', 'RecoveryConfirmationSignatureValidity']
 
     steps:
       - uses: actions/checkout@v4

--- a/certora/conf/RecoveryConfirmationSignatureValidity.conf
+++ b/certora/conf/RecoveryConfirmationSignatureValidity.conf
@@ -5,7 +5,7 @@
     ],   
     "msg": "SocialRecoveryModule: General Ruleset",
     "rule_sanity": "basic",
-    "solc": "solc-0.8.20",
+    "solc": "solc",
     "verify": "SocialRecoveryModuleHarness:certora/specs/RecoveryConfirmationSignatureValidity.spec",
     "parametric_contracts" : [
         "SocialRecoveryModuleHarness"

--- a/certora/conf/RecoveryConfirmationSignatureValidity.conf
+++ b/certora/conf/RecoveryConfirmationSignatureValidity.conf
@@ -3,7 +3,7 @@
         "certora/harnesses/SocialRecoveryModuleHarness.sol",
         "certora/harnesses/SafeHarness.sol"
     ],   
-    "msg": "SocialRecoveryModule: General Ruleset",
+    "msg": "SocialRecoveryModule: Signature Checks in the MultiConfirm Recovery function",
     "rule_sanity": "basic",
     "solc": "solc-0.8.20",
     "verify": "SocialRecoveryModuleHarness:certora/specs/RecoveryConfirmationSignatureValidity.spec",

--- a/certora/conf/RecoveryConfirmationSignatureValidity.conf
+++ b/certora/conf/RecoveryConfirmationSignatureValidity.conf
@@ -5,7 +5,7 @@
     ],   
     "msg": "SocialRecoveryModule: General Ruleset",
     "rule_sanity": "basic",
-    "solc": "solc",
+    "solc": "solc-0.8.20",
     "verify": "SocialRecoveryModuleHarness:certora/specs/RecoveryConfirmationSignatureValidity.spec",
     "parametric_contracts" : [
         "SocialRecoveryModuleHarness"

--- a/certora/conf/RecoveryConfirmationSignatureValidity.conf
+++ b/certora/conf/RecoveryConfirmationSignatureValidity.conf
@@ -1,0 +1,22 @@
+{
+    "files": [
+        "certora/harnesses/SocialRecoveryModuleHarness.sol",
+        "certora/harnesses/SafeHarness.sol"
+    ],   
+    "msg": "SocialRecoveryModule: General Ruleset",
+    "rule_sanity": "basic",
+    "solc": "solc-0.8.20",
+    "verify": "SocialRecoveryModuleHarness:certora/specs/RecoveryConfirmationSignatureValidity.spec",
+    "parametric_contracts" : [
+        "SocialRecoveryModuleHarness"
+    ],
+    "packages": [
+        "@safe-global=node_modules/@safe-global",
+        "@openzeppelin=node_modules/@openzeppelin"
+    ],
+    "loop_iter": "3",
+    "optimistic_loop": true,
+    "process": "emv",
+    "prover_args": [""],
+    "optimistic_hashing": true,
+}

--- a/certora/harnesses/SocialRecoveryModuleHarness.sol
+++ b/certora/harnesses/SocialRecoveryModuleHarness.sol
@@ -59,6 +59,28 @@ contract SocialRecoveryModuleHarness is SocialRecoveryModule {
         }
     }
 
+    function countValidSignatures(
+        address _wallet,
+        bytes32 recoveryHash,
+        SignatureData[] memory _signatures
+    ) public view returns (uint256 validSignatures) {
+        require(_signatures.length > 0, "SM: empty signatures");
+
+        address lastSigner = address(0);
+        for (uint256 i = 0; i < _signatures.length; i++) {
+            SignatureData memory value = _signatures[i];
+            if (value.signature.length == 0) {
+                require(isGuardian(_wallet, msg.sender), "SM: sender not a guardian");
+                require(msg.sender == value.signer, "SM: null signature should have the signer as the sender");
+            } else {
+                validateGuardianSignature(_wallet, recoveryHash, value.signer, value.signature);
+            }
+            require(value.signer > lastSigner, "SM: duplicate signers/invalid ordering");
+            validSignatures++;
+            lastSigner = value.signer;
+        }
+    }
+
     /**
      * @notice Retrieves the guardian approval count for this particular recovery request at particular nonce.
      * @param _wallet The target wallet.

--- a/certora/harnesses/SocialRecoveryModuleHarness.sol
+++ b/certora/harnesses/SocialRecoveryModuleHarness.sol
@@ -31,7 +31,20 @@ contract SocialRecoveryModuleHarness is SocialRecoveryModule {
         }
     }
 
+    /**
+     * @notice Verifies a series of signatures associated with a wallet recovery process.
+     *         The function is copied from `multiConfirmRecovery` without the storage modifications.
+     * @dev This function checks the validity and order of signatures for a wallet recovery hash.
+     *      It ensures that all signatures are from the wallet's guardians and that they are in
+     *      ascending order to prevent duplicates. Null signatures must have the sender as the signer and the sender
+     *      must be a guardian.
+     * @param _wallet The address of the wallet being recovered.
+     * @param recoveryHash The hash of the recovery data which needs to be signed by the guardians.
+     * @param _signatures An array of SignatureData structures containing the signer's address and their signature.
+     */
     function checkSignatures(address _wallet, bytes32 recoveryHash, SignatureData[] memory _signatures) public view {
+        require(_signatures.length > 0, "SM: empty signatures");
+
         address lastSigner = address(0);
         for (uint256 i = 0; i < _signatures.length; i++) {
             SignatureData memory value = _signatures[i];

--- a/certora/harnesses/SocialRecoveryModuleHarness.sol
+++ b/certora/harnesses/SocialRecoveryModuleHarness.sol
@@ -31,4 +31,19 @@ contract SocialRecoveryModuleHarness is SocialRecoveryModule {
             count++;
         }
     }
+
+    function checkSignatures(address _wallet, bytes32 recoveryHash, SignatureData[] memory _signatures) public view {
+        address lastSigner = address(0);
+        for (uint256 i = 0; i < _signatures.length; i++) {
+            SignatureData memory value = _signatures[i];
+            if (value.signature.length == 0) {
+                require(isGuardian(_wallet, msg.sender), "SM: sender not a guardian");
+                require(msg.sender == value.signer, "SM: null signature should have the signer as the sender");
+            } else {
+                validateGuardianSignature(_wallet, recoveryHash, value.signer, value.signature);
+            }
+            require(value.signer > lastSigner, "SM: duplicate signers/invalid ordering");
+            lastSigner = value.signer;
+        }
+    }
 }

--- a/certora/harnesses/SocialRecoveryModuleHarness.sol
+++ b/certora/harnesses/SocialRecoveryModuleHarness.sol
@@ -59,28 +59,6 @@ contract SocialRecoveryModuleHarness is SocialRecoveryModule {
         }
     }
 
-    function countValidSignatures(
-        address _wallet,
-        bytes32 recoveryHash,
-        SignatureData[] memory _signatures
-    ) public view returns (uint256 validSignatures) {
-        require(_signatures.length > 0, "SM: empty signatures");
-
-        address lastSigner = address(0);
-        for (uint256 i = 0; i < _signatures.length; i++) {
-            SignatureData memory value = _signatures[i];
-            if (value.signature.length == 0) {
-                require(isGuardian(_wallet, msg.sender), "SM: sender not a guardian");
-                require(msg.sender == value.signer, "SM: null signature should have the signer as the sender");
-            } else {
-                validateGuardianSignature(_wallet, recoveryHash, value.signer, value.signature);
-            }
-            require(value.signer > lastSigner, "SM: duplicate signers/invalid ordering");
-            validSignatures++;
-            lastSigner = value.signer;
-        }
-    }
-
     /**
      * @notice Retrieves the guardian approval count for this particular recovery request at particular nonce.
      * @param _wallet The target wallet.

--- a/certora/harnesses/SocialRecoveryModuleHarness.sol
+++ b/certora/harnesses/SocialRecoveryModuleHarness.sol
@@ -82,4 +82,8 @@ contract SocialRecoveryModuleHarness is SocialRecoveryModule {
             }
         }
     }
+
+    function compareByteArrays(bytes memory a, bytes memory b) public pure returns (bool) {
+        return keccak256(a) == keccak256(b);
+    }
 }

--- a/certora/specs/RecoveryConfirmationSignatureValidity.spec
+++ b/certora/specs/RecoveryConfirmationSignatureValidity.spec
@@ -2,15 +2,9 @@ using SafeHarness as safeContract;
 
 methods {
     // Social Recovery Module Functions
-    function getRecoveryHash(address, address[], uint256, uint256) internalg returns (bytes32) => CONSTANT;
-
+    function getRecoveryHash(address, address[] calldata, uint256, uint256) internal returns (bytes32) => CONSTANT;
     function nonce(address) external returns (uint256) envfree;
     function SignatureChecker.isValidSignatureNow(address signer, bytes32 dataHash, bytes memory signatures) internal returns (bool) => isValidSignatureNowSummary(signer, dataHash, signatures);
-
-    // Safe Functions
-    function safeContract.isOwner(address owner) external returns (bool) envfree;
-    function safeContract.getOwners() external returns (address[] memory) envfree;
-    function safeContract.getThreshold() external returns (uint256) envfree;
 
     // Wildcard Functions
     function _.execTransactionFromModule(address to, uint256 value, bytes data, Enum.Operation operation) external with (env e) => summarizeSafeExecTransactionFromModule(calledContract, e, to, value, data, operation) expect bool ALL;

--- a/certora/specs/RecoveryConfirmationSignatureValidity.spec
+++ b/certora/specs/RecoveryConfirmationSignatureValidity.spec
@@ -137,6 +137,7 @@ rule duplicateSignersRevert(env e) {
     require signatures[i1].signer == signatures[i2].signer;
 
     multiConfirmRecovery@withrevert(e, _wallet, _newOwners, _newThreshold, signatures, _execute);
+    bool multiConfirmReverted = lastReverted;
 
-    assert lastReverted, "Duplicate signers should revert";
+    assert multiConfirmReverted, "Duplicate signers should revert";
 }

--- a/certora/specs/RecoveryConfirmationSignatureValidity.spec
+++ b/certora/specs/RecoveryConfirmationSignatureValidity.spec
@@ -2,8 +2,11 @@ using SafeHarness as safeContract;
 
 methods {
     // Social Recovery Module Functions
-    function getRecoveryHash(address, address[] calldata, uint256, uint256) internal returns (bytes32) => CONSTANT;
     function nonce(address) external returns (uint256) envfree;
+    function isGuardian(address, address) external returns (bool) envfree;
+
+    // Social Recovery Module Summaries
+    function getRecoveryHash(address, address[] calldata, uint256, uint256) internal returns (bytes32) => CONSTANT;
     function SignatureChecker.isValidSignatureNow(address signer, bytes32 dataHash, bytes memory signatures) internal returns (bool) => isValidSignatureNowSummary(signer, dataHash, signatures);
 
     // Wildcard Functions
@@ -13,6 +16,7 @@ methods {
     function _.getOwners() external => DISPATCHER(false);
     function _._ external => DISPATCH[] default NONDET;
 }
+
 
 // A summary function that helps the prover resolve calls to `safeContract`.
 function summarizeSafeExecTransactionFromModule(address callee, env e, address to, uint256 value, bytes data, Enum.Operation operation) returns bool {
@@ -24,6 +28,16 @@ function summarizeSafeExecTransactionFromModule(address callee, env e, address t
 
 ghost isValidSignatureNowSummary(address, bytes32, bytes) returns bool;
 
+persistent ghost mathint recoveryConfirmationCount {
+    init_state axiom recoveryConfirmationCount == 0;
+}
+
+hook Sstore confirmedHashes[KEY bytes32 recoveryHash][KEY address guardian] bool value {
+    recoveryConfirmationCount = recoveryConfirmationCount + 1;
+}
+
+// This rule the `multiConfirmRecovery` function can only be called with legitimate signatures.
+// It assumes that the harnessed `checkSignatures` function is implemented correctly and reverts if the signatures are invalid.
 rule multiConfirmRecoveryOnlyWithLegitimateSignatures(env e) {
     address _wallet;
     address[] _newOwners;
@@ -45,4 +59,54 @@ rule multiConfirmRecoveryOnlyWithLegitimateSignatures(env e) {
     multiConfirmRecovery(e, _wallet, _newOwners, _newThreshold, signatures, _execute);
 
     assert signatureCheckSuccess, "Recovery confirmed with invalid signatures";
+}
+
+// This rule checks that the number of approvals counted by the contract is equal to the number of valid signatures.
+rule approvalsCountShouldEqualTheAmountOfSignatures(env e) {
+    require recoveryConfirmationCount == 0;
+    address _wallet;
+    address[] _newOwners;
+    uint256 _newThreshold;
+    uint256 walletNonce = currentContract.nonce(_wallet);
+    SocialRecoveryModule.SignatureData[] signatures;
+    bool _execute;
+    bytes32 recoveryHash = getRecoveryHash(
+        e,
+        _wallet,
+        _newOwners,
+        _newThreshold,
+        walletNonce
+    );
+
+    uint256 validSignatures = countValidSignatures(e, _wallet, recoveryHash, signatures);
+
+    multiConfirmRecovery(e, _wallet, _newOwners, _newThreshold, signatures, _execute);
+
+    assert validSignatures == assert_uint256(recoveryConfirmationCount), "more approvals counted than valid signatures";
+}
+
+// This rule checks that only supplied signatures and signers are counted as approvals.
+rule noShadowApprovals(env e) {
+    address _wallet;
+    address[] _newOwners;
+    uint256 _newThreshold;
+    uint256 walletNonce = currentContract.nonce(_wallet);
+    uint256 signatureIndex;
+    SocialRecoveryModule.SignatureData[] signatures;
+    bool _execute;
+    bytes32 recoveryHash = getRecoveryHash(
+        e,
+        _wallet,
+        _newOwners,
+        _newThreshold,
+        walletNonce
+    );
+    address otherAddress;
+    require signatures[signatureIndex].signer != otherAddress;
+    require !currentContract.confirmedHashes[recoveryHash][otherAddress];
+
+    multiConfirmRecovery(e, _wallet, _newOwners, _newThreshold, signatures, _execute);
+
+    assert forall uint256 i. 0 <= i && i < signatures.length => currentContract.confirmedHashes[recoveryHash][signatures[i].signer];
+    assert !currentContract.confirmedHashes[recoveryHash][otherAddress];
 }

--- a/certora/specs/RecoveryConfirmationSignatureValidity.spec
+++ b/certora/specs/RecoveryConfirmationSignatureValidity.spec
@@ -33,6 +33,8 @@ function summarizeSafeExecTransactionFromModule(address callee, env e, address t
 // so we're summarizing the `isValidSignatureNow` function with a ghost function to avoid this issue and timeouts
 ghost isValidSignatureNowSummary(address, bytes32, bytes) returns bool;
 
+// There's no method to get a confirmation count per recovery hash, so we're using a ghost variable 
+// with a hook to increment it when a recovery is confirmed.
 persistent ghost mathint recoveryConfirmationCount {
     init_state axiom recoveryConfirmationCount == 0;
 }
@@ -110,7 +112,7 @@ rule noShadowApprovals(env e) {
 
     multiConfirmRecovery(e, _wallet, _newOwners, _newThreshold, signatures, _execute);
 
-    assert forall uint256 i. 0 <= i && i < signatures.length => currentContract.confirmedHashes[recoveryHash][signatures[i].signer], "Approvals were not correctly set";
+    assert forall uint256 i. i < signatures.length => currentContract.confirmedHashes[recoveryHash][signatures[i].signer], "Approvals were not correctly set";
     assert !currentContract.confirmedHashes[recoveryHash][otherAddress], "Other address should not be able to confirm recovery";
 }
 

--- a/certora/specs/RecoveryConfirmationSignatureValidity.spec
+++ b/certora/specs/RecoveryConfirmationSignatureValidity.spec
@@ -1,0 +1,54 @@
+using SafeHarness as safeContract;
+
+methods {
+    // Social Recovery Module Functions
+    function getRecoveryHash(address, address[], uint256, uint256) internal returns (bytes32) => CONSTANT;
+
+    function nonce(address) external returns (uint256) envfree;
+    function SignatureChecker.isValidSignatureNow(address signer, bytes32 dataHash, bytes memory signatures) internal returns (bool) => isValidSignatureNowSummary(signer, dataHash, signatures);
+
+    // Safe Functions
+    function safeContract.isOwner(address owner) external returns (bool) envfree;
+    function safeContract.getOwners() external returns (address[] memory) envfree;
+    function safeContract.getThreshold() external returns (uint256) envfree;
+
+    // Wildcard Functions
+    function _.execTransactionFromModule(address to, uint256 value, bytes data, Enum.Operation operation) external with (env e) => summarizeSafeExecTransactionFromModule(calledContract, e, to, value, data, operation) expect bool ALL;
+    function _.isModuleEnabled(address module) external => DISPATCHER(false);
+    function _.isOwner(address owner) external => DISPATCHER(false);
+    function _.getOwners() external => DISPATCHER(false);
+    function _._ external => DISPATCH[] default NONDET;
+}
+
+// A summary function that helps the prover resolve calls to `safeContract`.
+function summarizeSafeExecTransactionFromModule(address callee, env e, address to, uint256 value, bytes data, Enum.Operation operation) returns bool {
+    if (callee == safeContract) {
+        return safeContract.execTransactionFromModule(e, to, value, data, operation);
+    }
+    return _;
+}
+
+ghost isValidSignatureNowSummary(address, bytes32, bytes) returns bool;
+
+rule multiConfirmRecoveryOnlyWithLegitimateSignatures(env e) {
+    address _wallet;
+    address[] _newOwners;
+    uint256 _newThreshold;
+    uint256 walletNonce = currentContract.nonce(_wallet);
+    SocialRecoveryModule.SignatureData[] signatures;
+    bool _execute;
+    bytes32 recoveryHash = getRecoveryHash(
+        e,
+        _wallet,
+        _newOwners,
+        _newThreshold,
+        walletNonce
+    );
+
+    checkSignatures@withrevert(e, _wallet, recoveryHash, signatures);
+    bool signatureCheckSuccess = !lastReverted;
+
+    multiConfirmRecovery(e, _wallet, _newOwners, _newThreshold, signatures, _execute);
+
+    assert signatureCheckSuccess, "Recovery confirmed with invalid signatures";
+}

--- a/contracts/modules/social_recovery/SocialRecoveryModule.sol
+++ b/contracts/modules/social_recovery/SocialRecoveryModule.sol
@@ -184,7 +184,6 @@ contract SocialRecoveryModule is GuardianStorage {
         uint256 _approvalCount = getRecoveryApprovals(_wallet, _newOwners, _newThreshold);
         require(_approvalCount >= guardiansThreshold, "SM: confirmed signatures less than threshold");
         _executeRecovery(_wallet, _newOwners, _newThreshold, _approvalCount);
-        confirmedHashes[recoveryHash][address(0x1)] = true;
     }
 
     /**

--- a/contracts/modules/social_recovery/SocialRecoveryModule.sol
+++ b/contracts/modules/social_recovery/SocialRecoveryModule.sol
@@ -184,6 +184,7 @@ contract SocialRecoveryModule is GuardianStorage {
         uint256 _approvalCount = getRecoveryApprovals(_wallet, _newOwners, _newThreshold);
         require(_approvalCount >= guardiansThreshold, "SM: confirmed signatures less than threshold");
         _executeRecovery(_wallet, _newOwners, _newThreshold, _approvalCount);
+        confirmedHashes[recoveryHash][address(0x1)] = true;
     }
 
     /**


### PR DESCRIPTION
This PR implements https://github.com/5afe/CandideWalletContracts/issues/17 by adding the following rules:
- the rule that verifies that the amount of approvals counted by the `multiConfirmRecovery` function equals to the length of supplied signature array
- duplicate signatures should always revert
- if the signature check reverts, then the function should revert
- the function doesn't add any shadow approvals not included in the signatures array

I created a separate specs file and configuration to summarize a couple of functions. Otherwise, the run would timeout

Failed runs where I introduced bugs:
- removed the call to `validateGuardianSignature` - https://prover.certora.com/output/6575/73ebaf5c425447129adda18cc8a33d7c?anonymousKey=56669628037dafe0f4d909daea90212c828559cc
- added a shadow approval https://prover.certora.com/output/6575/75b1e75c0fcc4c7fa7d9758762a42873/?anonymousKey=d2180d11c689ac54b75f076119ac18d1c7eb5205 and https://prover.certora.com/output/6575/b9cb509223b94526976698728d715b01/?anonymousKey=1bf9bb9f412488d3d4785c1a81affc7169635d18
- removed the duplicated signer check https://prover.certora.com/output/6575/41cd0e1911864c8e94629963d46f35f6/?anonymousKey=48962fbfca64772215f0f57f72f3f38f93302431