### PR TITLE
FV: Safe access to guardians and threshold

### DIFF
--- a/certora/specs/SocialRecoveryModule.spec
+++ b/certora/specs/SocialRecoveryModule.spec
@@ -475,21 +475,20 @@ rule safeContractAccessToGuardiansAndThreshold(env e, address guardian, uint256 
 
     bool isGuardianInOtherSafeContract = currentContract.isGuardian(otherSafeContract, guardian);
 
-    currentContract.addGuardianWithThreshold@withrevert(e, guardian, threshold);
-    bool addGuardianSuccess = !lastReverted;
+    currentContract.addGuardianWithThreshold(e, guardian, threshold);
 
-    assert addGuardianSuccess =>
-        currentContract.isGuardian(safeContract, guardian) &&
+    assert currentContract.isGuardian(safeContract, guardian) &&
         threshold == currentContract.entries[safeContract].threshold &&
         (isGuardianInOtherSafeContract == currentContract.isGuardian(otherSafeContract, guardian));
     
-    uint256 currentCount = currentContract.entries[safeContract].count;
+    uint256 currentGuardiansCount = currentContract.entries[safeContract].count;
 
     currentContract.revokeGuardianWithThreshold@withrevert(e, SENTINEL(), guardian, threshold);
-    bool revokeGuardianSuccess = !lastReverted;
+    bool success = !lastReverted;
 
-    assert addGuardianSuccess && threshold < currentCount =>
-        revokeGuardianSuccess &&
+    assert threshold < currentGuardiansCount =>
+        success &&
+        !currentContract.isGuardian(safeContract, guardian) &&
         threshold == currentContract.entries[safeContract].threshold &&
         (isGuardianInOtherSafeContract == currentContract.isGuardian(otherSafeContract, guardian));
 }


### PR DESCRIPTION
Fixes #9 

This PR adds one rule to check that actions done by one safe should not affect another safe smart account.

Here we also require that the `otherSafeContract` be different from `safeContract` instead of implications as the rule specifically looks for that case.