### PR TITLE
Dispatcher based update

### DIFF
--- a/certora/specs/RecoveryConfirmationSignatureValidity.spec
+++ b/certora/specs/RecoveryConfirmationSignatureValidity.spec
@@ -13,20 +13,11 @@ methods {
     function SignatureChecker.isValidSignatureNow(address signer, bytes32 dataHash, bytes memory signature) internal returns (bool) => isValidSignatureNowSummary(signer, dataHash, signature);
 
     // Wildcard Functions
-    function _.execTransactionFromModule(address to, uint256 value, bytes data, Enum.Operation operation) external with (env e) => summarizeSafeExecTransactionFromModule(calledContract, e, to, value, data, operation) expect bool ALL;
+    function _.execTransactionFromModule(address to, uint256 value, bytes data, Enum.Operation operation) external => DISPATCHER(false);
     function _.isModuleEnabled(address module) external => DISPATCHER(false);
     function _.isOwner(address owner) external => DISPATCHER(false);
     function _.getOwners() external => DISPATCHER(false);
     function _._ external => DISPATCH[] default NONDET;
-}
-
-
-// A summary function that helps the prover resolve calls to `safeContract`.
-function summarizeSafeExecTransactionFromModule(address callee, env e, address to, uint256 value, bytes data, Enum.Operation operation) returns bool {
-    if (callee == safeContract) {
-        return safeContract.execTransactionFromModule(e, to, value, data, operation);
-    }
-    return _;
 }
 
 // The prover analysis fails in functions with heavy use of assembly code,

--- a/certora/specs/SocialRecoveryModule.spec
+++ b/certora/specs/SocialRecoveryModule.spec
@@ -441,6 +441,7 @@ rule finalizeRecovery(env e) {
     assert success => require_uint64(e.block.timestamp) >= executeAfter;
     assert !success =>
         safeContract.getOwners().length == 0 ||
+        safeContract.isModuleEnabled(currentContract) ||
         currentContract.walletsNonces[safeContract] == 0 ||
         executeAfter == 0 ||
         e.msg.value != 0 ||


### PR DESCRIPTION
This PR updates the summary with `DISPATCHER(false)` in `RecoveryConfirmationSignatureValidity.spec` as for most cases, it works as intended (i.e. find the correct implementation from the available contracts) and a summary is not required (to include possible reverting paths as well).

Also, we found one case which should be checked (`isModuleEnabled(...)`) but was ignored because we used a summary before.