### PR TITLE
Dispatcher update in `SocialRecoveryModule.spec`

### DIFF
--- a/certora/harnesses/SocialRecoveryModuleHarness.sol
+++ b/certora/harnesses/SocialRecoveryModuleHarness.sol
@@ -82,8 +82,4 @@ contract SocialRecoveryModuleHarness is SocialRecoveryModule {
             }
         }
     }
-
-    function compareByteArrays(bytes memory a, bytes memory b) public pure returns (bool) {
-        return keccak256(a) == keccak256(b);
-    }
 }

--- a/certora/specs/RecoveryConfirmationSignatureValidity.spec
+++ b/certora/specs/RecoveryConfirmationSignatureValidity.spec
@@ -13,20 +13,11 @@ methods {
     function SignatureChecker.isValidSignatureNow(address signer, bytes32 dataHash, bytes memory signature) internal returns (bool) => isValidSignatureNowSummary(signer, dataHash, signature);
 
     // Wildcard Functions
-    function _.execTransactionFromModule(address to, uint256 value, bytes data, Enum.Operation operation) external with (env e) => summarizeSafeExecTransactionFromModule(calledContract, e, to, value, data, operation) expect bool ALL;
+    function _.execTransactionFromModule(address to, uint256 value, bytes data, Enum.Operation operation) external => DISPATCHER(false);
     function _.isModuleEnabled(address module) external => DISPATCHER(false);
     function _.isOwner(address owner) external => DISPATCHER(false);
     function _.getOwners() external => DISPATCHER(false);
     function _._ external => DISPATCH[] default NONDET;
-}
-
-
-// A summary function that helps the prover resolve calls to `safeContract`.
-function summarizeSafeExecTransactionFromModule(address callee, env e, address to, uint256 value, bytes data, Enum.Operation operation) returns bool {
-    if (callee == safeContract) {
-        return safeContract.execTransactionFromModule(e, to, value, data, operation);
-    }
-    return _;
 }
 
 // The prover analysis fails in functions with heavy use of assembly code,

--- a/certora/specs/RecoveryConfirmationSignatureValidity.spec
+++ b/certora/specs/RecoveryConfirmationSignatureValidity.spec
@@ -4,20 +4,12 @@ methods {
     // Social Recovery Module Functions
     function nonce(address) external returns (uint256) envfree;
     function isGuardian(address, address) external returns (bool) envfree;
-    function compareByteArrays(bytes, bytes) external returns (bool) envfree;
 
     // Social Recovery Module Summaries
     function getRecoveryHash(address, address[] calldata, uint256, uint256) internal returns (bytes32) => CONSTANT;
     // The prover analysis fails in functions with heavy use of assembly code,
     // so we're summarizing the `isValidSignatureNow` function with a ghost function to avoid this issue and timeouts
     function SignatureChecker.isValidSignatureNow(address signer, bytes32 dataHash, bytes memory signature) internal returns (bool) => isValidSignatureNowSummary(signer, dataHash, signature);
-
-    // Wildcard Functions
-    function _.execTransactionFromModule(address to, uint256 value, bytes data, Enum.Operation operation) external => DISPATCHER(false);
-    function _.isModuleEnabled(address module) external => DISPATCHER(false);
-    function _.isOwner(address owner) external => DISPATCHER(false);
-    function _.getOwners() external => DISPATCHER(false);
-    function _._ external => DISPATCH[] default NONDET;
 }
 
 // The prover analysis fails in functions with heavy use of assembly code,

--- a/certora/specs/SocialRecoveryModule.spec
+++ b/certora/specs/SocialRecoveryModule.spec
@@ -441,6 +441,7 @@ rule finalizeRecovery(env e) {
     assert success => require_uint64(e.block.timestamp) >= executeAfter;
     assert !success =>
         safeContract.getOwners().length == 0 ||
+        safeContract.isModuleEnabled(currentContract) ||
         currentContract.walletsNonces[safeContract] == 0 ||
         executeAfter == 0 ||
         e.msg.value != 0 ||


### PR DESCRIPTION
This PR updates the summary to use `DISPATCHER(true)` for the `execTransactionFromModule`.

From Certora Team:

> DISPATCHER(false) and DISPATCHER(true) both first try any known Contract.   The difference should be only if a different contract is called which is not explicitly linked into the scene.  With DISPATCHER(true) the prover just assumes that this will never happens.  It only tries those input values for which you only call known contracts.   With DISPATCHER(false), the prover will also consider the case you call an unknown contract and in that case assumes the worst, i.e. all ghost variables are havoced and the return value is arbitrary.  So you get a lot of spurious counterexamples with DISPATCHER(false), but with DISPATCHER(true) you are technically unsound, as you don’t verify anything if unknown contracts could be called.

So, In our case, as we already summarized call to `execTransactionFromModule(...)` if `callee` is `safeContract` before. And as the summary goes for the non-reverting path, I think it is safe to use `DISPATCHER(true)` here.

P.S. For the `RecoveryConfirmationSignatureValidity.spec`, as we didn't require some method specified, that was removed, along with an extra harness function.