### PR TITLE
Update the Certora CI to run only when Key is available

### DIFF
--- a/.github/workflows/certora_recovery.yml
+++ b/.github/workflows/certora_recovery.yml
@@ -43,7 +43,10 @@ jobs:
 
       - name: Verify rule ${{ matrix.rule }}
         run: |
-          echo "Certora key length" ${#CERTORAKEY}
-          certoraRun certora/conf/${{ matrix.rule }}.conf --wait_for_results=all
+          if [ -n "${{ secrets.CERTORA_KEY }}" ]; then
+            certoraRun certora/conf/${{ matrix.rule }}.conf --wait_for_results=all
+          else
+            echo "CERTORA_KEY secret is not present, skipping certoraRun command."
+          fi
         env:
           CERTORAKEY: ${{ secrets.CERTORA_KEY }}

--- a/.github/workflows/certora_recovery.yml
+++ b/.github/workflows/certora_recovery.yml
@@ -44,9 +44,9 @@ jobs:
       - name: Verify rule ${{ matrix.rule }}
         run: |
           if [[ -n "${#CERTORA_KEY}" ]]; then
-            certoraRun certora/conf/${{ matrix.rule }}.conf --wait_for_results=all
-          else
             echo "CERTORA_KEY secret is not present, skipping certoraRun command."
+          else
+            certoraRun certora/conf/${{ matrix.rule }}.conf --wait_for_results=all
           fi
         env:
           CERTORAKEY: ${{ secrets.CERTORA_KEY }}

--- a/.github/workflows/certora_recovery.yml
+++ b/.github/workflows/certora_recovery.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Verify rule ${{ matrix.rule }}
         run: |
-          if [ -n "${{ secrets.CERTORA_KEY }}" ]; then
+          if [[ -n "${#CERTORA_KEY}" ]]; then
             certoraRun certora/conf/${{ matrix.rule }}.conf --wait_for_results=all
           else
             echo "CERTORA_KEY secret is not present, skipping certoraRun command."


### PR DESCRIPTION
This PR updates the Certora CI workflow to only run when there is a valid key available, else will skip the CI Check.